### PR TITLE
676: Ensure authorize request jwt conforms to FAPI spec

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -27,52 +27,17 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
+          "comment": "Ensure authorize request object is FAPI compliant",
+          "name": "FapiAuthorizeRequestFilter",
+          "type": "ScriptableFilter",
           "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
+            "type": "application/x-groovy",
+            "file": "FapiCompliantAuthorizeRequestFilter.groovy",
+            "args": {
+              "comment": "TODO: use env variable"
             }
           }
-        },
-        {
-          "comment": "Add the extracted cert thumbprint to the token request",
-          "name": "AddCnf",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "AddCnfKey.groovy"
-          }
-        },
-        {
-          "comment": "Add gateway access token to request (custom AT modification script checks access token to enforce route via IG)",
-          "type": "ClientCredentialsOAuth2ClientFilter",
-          "config": {
-            "clientId": "&{ig.client.id}",
-            "clientSecretId": "ig.client.secret",
-            "secretsProvider": "SystemAndEnvSecretStore-IAM",
-            "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
-            "scopes": [
-              "trusted_gateway"
-            ],
-            "handler": "TokenRequestHandler"
-          }
-        },
-        {
-          "comment": "Add gateway access token to downstream request",
-          "name": "AddGatewayAuthorization",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "AddGatewayAuthorization.groovy"
-          }
-        }
+        }        
       ],
       "handler": "SBATReverseProxyHandlerIdentityPlatform"
     }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -1,0 +1,80 @@
+{
+  "comment": "Ensure FAPI compliant authorize requests",
+  "name": "04 - Open Banking Authorize endpoint",
+  "auditService": "AuditService-OB-Route",
+  "baseURI": "https://&{identity.platform.fqdn}",
+  "condition": "${matches(request.uri.path, '^/am/oauth2/realms/root/realms/&{am.realm}/authorize')}",
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "comment": "Add host to downstream request",
+          "name": "HeaderFilter-ChangeHostToIAM",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host"
+            ],
+            "add": {
+              "X-Forwarded-Host": [
+                "&{ig.fqdn}"
+              ]
+            }
+          }
+        },
+        {
+          "comment": "Extract client certificate thumbprint for cert bound access tokens",
+          "name": "CertificateThumbprintFilter-1",
+          "type": "CertificateThumbprintFilter",
+          "config": {
+            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "failureHandler": {
+              "type": "ScriptableHandler",
+              "config": {
+                "type": "application/x-groovy",
+                "file": "ReturnInvalidCnfKeyError.groovy"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Add the extracted cert thumbprint to the token request",
+          "name": "AddCnf",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "AddCnfKey.groovy"
+          }
+        },
+        {
+          "comment": "Add gateway access token to request (custom AT modification script checks access token to enforce route via IG)",
+          "type": "ClientCredentialsOAuth2ClientFilter",
+          "config": {
+            "clientId": "&{ig.client.id}",
+            "clientSecretId": "ig.client.secret",
+            "secretsProvider": "SystemAndEnvSecretStore-IAM",
+            "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
+            "scopes": [
+              "trusted_gateway"
+            ],
+            "handler": "TokenRequestHandler"
+          }
+        },
+        {
+          "comment": "Add gateway access token to downstream request",
+          "name": "AddGatewayAuthorization",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "AddGatewayAuthorization.groovy"
+          }
+        }
+      ],
+      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+    }
+  }
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -66,7 +66,7 @@ switch (httpMethod.toUpperCase()) {
         String[] requiredClaims = [ "scope", "state", "nonce" ]
         for (requiredClaim in requiredClaims) {
             if ( !requestJwtHasClaim(requiredClaim, requestJwtClaimSet) ) {
-                return logMissingClaimAndGetBadRequestResponse(requiredClaim)
+                return logMissingClaimAndGetBadRequestResponse("invalid_request", requiredClaim)
             }    
         }
 
@@ -84,7 +84,7 @@ private Response isRequestValidForRedirection(requestJwtClaims) {
     String[] requiredClaims = ['redirect_uri', 'client_id']
     for ( requiredClaim in requiredClaims ) {
         if (!requestJwtHasClaim(reqiredClaim, requestJwtClaims) ) {
-            return logMissingClaimAndGetBadRequestResponse(requiredClaim)
+            return logMissingClaimAndGetBadRequestResponse("invalid_request", requiredClaim)
         }
     }
     return null
@@ -94,8 +94,8 @@ private Boolean requestJwtHasClaim(String claimName, JwtClaimsSet requestJwtClai
     return requestJwtClaims.getClaim(claimName)?true:false
 }
 
-private Response logMissingClaimAndGetBadRequestResponse(String claimName) {
-    String errorString = "Invalid Request JWT: must have '" + claimName + "' claim"
+private Response logMissingClaimAndGetBadRequestResponse(String errorType, String claimName) {
+    String errorString = "error: " + errorType + "\nerrorDescription: Invalid Request JWT: must have '" + claimName + "' claim"
     logger.info(SCRIPT_NAME + errorString)
     return createBadRequestResponse(errorString)
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -108,6 +108,7 @@ private JwtReconstruction getRequestJtw() {
     }
     try{
         return new JwtReconstruction().reconstructJwt(requestJwtString, SignedJwt.class)
+    }
     catch (e){
         logger.info(SCRIPT_NAME + "BAD_REQUEST: Could not parse request JWT string", e)
         return null

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -1,35 +1,34 @@
 import groovy.json.JsonSlurper
 import org.forgerock.json.jose.jws.SignedJwt
 import org.forgerock.json.jose.common.JwtReconstruction
-import com.securebanking.gateway.dcr.ErrorResponseFactory
+//import com.securebanking.gateway.dcr.ErrorResponseFactory
 import org.forgerock.http.protocol.Status
 
 /**
- * This script checks that the call to the /authorize endpoint is 
- * correctly formed and valid. 
- * 
+ * This script checks that the call to the /authorize endpoint is
+ * correctly formed and valid.
+ *
  * Relevant specifications:
  * OAuth 2.0 spec: https://www.rfc-editor.org/rfc/rfc6749#section-4.1
  * FAPI Part 1: https://openid.net/specs/openid-financial-api-part-1-1_0.html#authorization-server
  * FAPI Part 2: https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server
  *
- * 
+ *
  */
 
-def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
-if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
-SCRIPT_NAME = "[FapiCompliantAuthorizeRequestFilter] (" + fapiInteractionId + ") - "
-logger.debug(SCRIPT_NAME + "Running...")
+def fapiInteractionId = request.getHeaders().getFirst('x-fapi-interaction-id')
+if (fapiInteractionId == null) fapiInteractionId = 'No x-fapi-interaction-id'
+SCRIPT_NAME = '[FapiCompliantAuthorizeRequestFilter] (' + fapiInteractionId + ') - '
+logger.debug(SCRIPT_NAME + 'Running...')
 
-def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
+//def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
 
 def httpMethod = request.method
 
-switch(httpMethod.toUpperCase()){
-    case "GET":
+switch (httpMethod.toUpperCase()) {
+    case 'GET':
         // Parse incoming registration JWT
-        logger.debug(SCRIPT_NAME + "Parsing authorize request")
-        def authRequestJwt
+        logger.debug(SCRIPT_NAME + 'Parsing authorize request')
 
         // From the OAuth 2.0 Spec:
         // If the request fails due to a missing, invalid, or mismatching
@@ -38,18 +37,20 @@ switch(httpMethod.toUpperCase()){
         // error and MUST NOT automatically redirect the user-agent to the
         // invalid redirection URI.
         // From the FAPI Part 1 Spec:
-        // shall only use the parameters included in the signed request object passed via the request or request_uri parameter
-        def reqeustJwt = getRequestJtw()
-        if(!requestJwt) {
-            return createBadRequestResponse("Request must have a 'request' query parameter the value of which must be a signed jwt")
+        // Shall only use the parameters included in the signed request object passed via the request or request_uri
+        // parameter
+        def requestJwt = getRequestJtw()
+        if (!requestJwt) {
+            return createBadRequestResponse("Request must have a 'request' query parameter the value of which must be "
+            + 'a signed jwt')
         }
 
         def errorMessage = isRequestValidForRedirection(requestJwt)
-        if(errorMessage != null){
+        if (errorMessage != null) {
             return createBadRequestResponse(errorMessage)
         }
 
-        // // If we can validate the redirect_uris then any 
+        // // If we can validate the redirect_uris then any
 
         // def requestQueryParam = getQueryParamFromRequest("request")
         // if(!requestQueryParam){
@@ -66,20 +67,19 @@ switch(httpMethod.toUpperCase()){
         // }
         // def authRequestClaims = authRequestJwt.getClaimsSet()
 
-        // def scopes = authRequestClaims.getClaim("scope")
-        // if (!scopes){
-        //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
-        //     return redirectWithError("Badly formed request jwt: must contain scope claim")
-        // }
+    // def scopes = authRequestClaims.getClaim("scope")
+    // if (!scopes){
+    //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
+    //     return redirectWithError("Badly formed request jwt: must contain scope claim")
+    // }
     default:
-        logger.debug(SCRIPT_NAME + "Method not supported")
+        logger.debug(SCRIPT_NAME + 'Method not supported')
         return new Response(Status.NOT_FOUND)
 }
 
 return next.handle(context, request)
 
-
-private Response createBadRequestResponse(errorMessage){
+private Response createBadRequestResponse(errorMessage) {
     def badRequestResponse = new Response(Status.BAD_REQUEST)
     badRequestResponse.setEntity(errorMessage)
     return badRequestResponse
@@ -87,30 +87,30 @@ private Response createBadRequestResponse(errorMessage){
 
 private String isRequestValidForRedirection(requestJwt) {
     def requestJwtClaims = requestJwt.getClaimsSet()
-    def redirectUri = requestJwtClaims.getClaim("redirect_uri")
+    def redirectUri = requestJwtClaims.getClaim('redirect_uri')
 
-    if(!redirectUri){
-        return "The request JWT has no or redirect_uri claim"
+    if (!redirectUri) {
+        return 'The request JWT has no or redirect_uri claim'
     }
 
-    if(!requestJwtClaims.getClaim("client_id")){
-        return "The request JWT has no or client_id claim"
+    if (!requestJwtClaims.getClaim('client_id')) {
+        return 'The request JWT has no or client_id claim'
     }
 
     return null
 }
 
 private JwtReconstruction getRequestJtw() {
-    def requestJwtString  = getQueryParamFromrequest("request")
-    if (!requestJwtString){
-        logger.info(SCRIPT_NAME + "BAD_REQUEST: /authorize request must have a request query parameter")
+    String requestJwtString  = getQueryParamFromrequest('request')
+    if (!requestJwtString) {
+        logger.info(SCRIPT_NAME + 'BAD_REQUEST: /authorize request must have a request query parameter')
         return null
     }
-    try{
+    try {
         return new JwtReconstruction().reconstructJwt(requestJwtString, SignedJwt.class)
     }
-    catch (e){
-        logger.info(SCRIPT_NAME + "BAD_REQUEST: Could not parse request JWT string", e)
+    catch (e) {
+        logger.info(SCRIPT_NAME + 'BAD_REQUEST: Could not parse request JWT string', e)
         return null
     }
 }
@@ -131,20 +131,20 @@ private JwtReconstruction getRequestJtw() {
 // }
 
 /**
- *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with this name exists 
+ *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with this name exists
  */
-private String getQueryParamFromRequest(paramName) {
-    def value = request.getQueryParams().get(paramName)
+// private String getQueryParamFromRequest(paramName) {
+//     def value = request.getQueryParams().get(paramName)
 
-    if ( !value ) {
-        logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
-        return null
-    }
+//     if ( !value ) {
+//         logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
+//         return null
+//     }
 
-    if ( value.size != 1 ) {
-        logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
-        return null
-    } 
-    
-    return value
-}
+//     if ( value.size != 1 ) {
+//         logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
+//         return null
+//     }
+
+//     return value
+// }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -1,0 +1,36 @@
+import groovy.json.JsonSlurper
+import com.forgerock.securebanking.uk.gateway.jwks.*
+import java.security.SignatureException
+import com.nimbusds.jose.jwk.RSAKey;
+import com.securebanking.gateway.dcr.ErrorResponseFactory
+import static org.forgerock.util.promise.Promises.newResultPromise
+
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
+SCRIPT_NAME = "[ProcessRegistration] (" + fapiInteractionId + ") - "
+logger.debug(SCRIPT_NAME + "Running...")
+
+def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
+
+def httpMethod = request.method
+
+switch(method.toUpperCase()){
+    case "GET":
+        // Parse incoming registration JWT
+        logger.debug(SCRIPT_NAME + "Parsing authorize request");
+        def authRequestJwt
+        try {
+            authRequestJwt = new JwtReconstruction().reconstructJwt(request.getQueryParams().get("request"), SignedJwt.class)
+        } catch (e) {
+            logger.warn(SCRIPT_NAME + "failed to decode registration request JWT", e)
+            return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")
+        }
+        def authRequestClaims = authRequestJwt.getClaimsSet()
+
+        def scopes = authRequestClaims.getClaim("scope")
+        if (!scopes){
+            return errorResponseFactory.invalidClientMetadataErrorResponse("Badly formed request jwt: must contain valid scope")
+        }
+
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -101,7 +101,7 @@ private String isRequestValidForRedirection(requestJwt) {
 }
 
 private JwtReconstruction getRequestJtw() {
-    String requestJwtString  = getQueryParamFromrequest('request')
+    String requestJwtString  = getQueryParamFromRequest('request')
     if (!requestJwtString) {
         logger.info(SCRIPT_NAME + 'BAD_REQUEST: /authorize request must have a request query parameter')
         return null
@@ -133,18 +133,18 @@ private JwtReconstruction getRequestJtw() {
 /**
  *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with this name exists
  */
-// private String getQueryParamFromRequest(paramName) {
-//     def value = request.getQueryParams().get(paramName)
+private String getQueryParamFromRequest(paramName) {
+    def value = request.getQueryParams().get(paramName)
 
-//     if ( !value ) {
-//         logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
-//         return null
-//     }
+    if ( !value ) {
+        logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
+        return null
+    }
 
-//     if ( value.size != 1 ) {
-//         logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
-//         return null
-//     }
+    if ( value.size != 1 ) {
+        logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
+        return null
+    }
 
-//     return value
-// }
+    return value
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -2,6 +2,7 @@ import groovy.json.JsonSlurper
 import org.forgerock.json.jose.jws.SignedJwt
 import org.forgerock.json.jose.common.JwtReconstruction
 import com.securebanking.gateway.dcr.ErrorResponseFactory
+import org.forgerock.http.protocol.Status
 
 
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
@@ -18,26 +19,62 @@ switch(httpMethod.toUpperCase()){
         // Parse incoming registration JWT
         logger.debug(SCRIPT_NAME + "Parsing authorize request")
         def authRequestJwt
-        try {
-            def requestQueryParam = request.getQueryParams().get("request")
-            if(!requestQueryParam) {
-                return errorResponseFactory.invalidClientMetadataErrorResponse("/authorize endpoint request must include request query parameter")
-            } else {
-              logger.debug(SCRIPT_NAME + " requestQueryParam is " + requestQueryParam[0])
-            }
+        
+        def requestQueryParam = getQueryParamFromRequest("request")
+        if(!requestQueryParam){
+            return errorResponseFactory.invalidRedirectUriErrorResponse(SCRIPT_NAME)
+        } else {
+            logger.debug(SCRIPT_NAME + " requestQueryParam is " + requestQueryParam[0])
+        }
 
-            authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam[0], SignedJwt.class)
+        try {
+            authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam, SignedJwt.class)
         } catch (e) {
-            logger.warn(SCRIPT_NAME + "failed to decode registration request JWT", e)
+            logger.warn(SCRIPT_NAME + "Badly formed request jwt: failed to decode registration request JWT", e)
             return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")
         }
         def authRequestClaims = authRequestJwt.getClaimsSet()
 
         def scopes = authRequestClaims.getClaim("scope")
         if (!scopes){
-            return errorResponseFactory.invalidClientMetadataErrorResponse("Badly formed request jwt: must contain valid scope")
+            logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
+            return redirectWithError("Badly formed request jwt: must contain scope claim")
         }
     default:
         logger.debug(SCRIPT_NAME + "Method not supported")
-        return next.handle(context, request)
+        return new Response(Status.NOT_FOUND)
+}
+
+return next.handle(context, request)
+
+private Response redirectWithError(errorString) {
+    def redirect_uri = getQueryParamFromRequest("redirect_uri")
+    def state = getQueryParamFromRequest("state")
+    if (!state){
+        redirect_uri = redirect_uri + "?error=" + "invalid_scope" + "&error_description=" + errorString
+    } else {
+        redirect_uri = redirect_uri + "?error=" + "invalid_scope" + "&error_description=" + errorString + "&state=" + state
+    }
+    def response = new Response(Status.FOUND)
+    logger.debug(SCRIPT_NAME + " redirect_url is " + url)
+    response.getHeaders().add("Location", redirect_uri)
+    return response
+}
+
+/*
+ *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with this name exists 
+*/
+private String getQueryParamFromRequest(paramName) {
+    def value = request.getQueryParams().get(paramName)
+    if ( !value ) {
+        logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
+        return null
+    } else {
+        if ( value.size != 1 ) {
+            logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
+            return null
+        } else (
+            return value[0]
+        )
+    }
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -67,11 +67,12 @@ switch (httpMethod.toUpperCase()) {
         // }
         // def authRequestClaims = authRequestJwt.getClaimsSet()
 
-    // def scopes = authRequestClaims.getClaim("scope")
-    // if (!scopes){
-    //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
-    //     return redirectWithError("Badly formed request jwt: must contain scope claim")
-    // }
+        // def scopes = authRequestClaims.getClaim("scope")
+        // if (!scopes){
+        //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
+        //     return redirectWithError("Badly formed request jwt: must contain scope claim")
+        // }
+        break
     default:
         logger.debug(SCRIPT_NAME + 'Method not supported')
         return new Response(Status.NOT_FOUND)
@@ -90,17 +91,17 @@ private String isRequestValidForRedirection(requestJwt) {
     def redirectUri = requestJwtClaims.getClaim('redirect_uri')
 
     if (!redirectUri) {
-        return 'The request JWT has no or redirect_uri claim'
+        return 'Invalid Request JWT: must have a redirect_uri claim'
     }
 
     if (!requestJwtClaims.getClaim('client_id')) {
-        return 'The request JWT has no or client_id claim'
+        return 'Invalid Request JWT: must have a client_id claim'
     }
 
     return null
 }
 
-private JwtReconstruction getRequestJtw() {
+private SignedJwt getRequestJtw() {
     String requestJwtString  = getQueryParamFromRequest('request')
     if (!requestJwtString) {
         logger.info(SCRIPT_NAME + 'BAD_REQUEST: /authorize request must have a request query parameter')
@@ -131,20 +132,21 @@ private JwtReconstruction getRequestJtw() {
 // }
 
 /**
- *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with this name exists
+ *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with
+ *  this name exists
  */
 private String getQueryParamFromRequest(paramName) {
     def value = request.getQueryParams().get(paramName)
 
     if ( !value ) {
-        logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
+        logger.info(SCRIPT_NAME + 'No query parameter of name ' + paramName + ' exists in the request')
         return null
     }
 
     if ( value.size != 1 ) {
-        logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
+        logger.info(SCRIPT_NAME + 'There are ' + value.size + ' values for request parameter ' + paramName)
         return null
     }
 
-    return value
+    return value[0]
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import org.forgerock.json.jose.common.JwtReconstruction
 import com.securebanking.gateway.dcr.ErrorResponseFactory
 
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import org.forgerock.json.jose.jws.SignedJwt
 import org.forgerock.json.jose.common.JwtReconstruction
 import com.securebanking.gateway.dcr.ErrorResponseFactory
 
@@ -12,7 +13,7 @@ def errorResponseFactory = new ErrorResponseFactory(SCRIPT_NAME)
 
 def httpMethod = request.method
 
-switch(method.toUpperCase()){
+switch(httpMethod.toUpperCase()){
     case "GET":
         // Parse incoming registration JWT
         logger.debug(SCRIPT_NAME + "Parsing authorize request")
@@ -21,9 +22,11 @@ switch(method.toUpperCase()){
             def requestQueryParam = request.getQueryParams().get("request")
             if(!requestQueryParam) {
                 return errorResponseFactory.invalidClientMetadataErrorResponse("/authorize endpoint request must include request query parameter")
+            } else {
+              logger.debug(SCRIPT_NAME + " requestQueryParam is " + requestQueryParam[0])
             }
 
-            authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam, SignedJwt.class)
+            authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam[0], SignedJwt.class)
         } catch (e) {
             logger.warn(SCRIPT_NAME + "failed to decode registration request JWT", e)
             return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -71,26 +71,6 @@ switch (httpMethod.toUpperCase()) {
             }    
         }
 
-        // def requestQueryParam = getQueryParamFromRequest("request")
-        // if(!requestQueryParam){
-        //     return errorResponseFactory.invalidRedirectUriErrorResponse(SCRIPT_NAME)
-        // } else {
-        //     logger.debug(SCRIPT_NAME + " requestQueryParam is " + requestQueryParam[0])
-        // }
-
-        // try {
-        //     authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam, SignedJwt.class)
-        // } catch (e) {
-        //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: failed to decode registration request JWT", e)
-        //     return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")
-        // }
-        // def authRequestClaims = authRequestJwt.getClaimsSet()
-
-        // def scopes = authRequestClaims.getClaim("scope")
-        // if (!scopes){
-        //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
-        //     return redirectWithError("Badly formed request jwt: must contain scope claim")
-        // }
         break
     default:
         logger.debug(SCRIPT_NAME + 'Method not supported')
@@ -101,7 +81,7 @@ logger.info("Request is FAPI compliant - calling next.handle")
 return next.handle(context, request)
 
 
-private Boolean requestJwtHasClaim(String claimName, JwtClaimSet requestJwtClaims) {
+private Boolean requestJwtHasClaim(String claimName, JwtClaimsSet requestJwtClaims) {
     return requestJwtClaims.getClaim(claimName)?true:false
 }
 

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -4,6 +4,17 @@ import org.forgerock.json.jose.common.JwtReconstruction
 import com.securebanking.gateway.dcr.ErrorResponseFactory
 import org.forgerock.http.protocol.Status
 
+/**
+ * This script checks that the call to the /authorize endpoint is 
+ * correctly formed and valid. 
+ * 
+ * Relevant specifications:
+ * OAuth 2.0 spec: https://www.rfc-editor.org/rfc/rfc6749#section-4.1
+ * FAPI Part 1: https://openid.net/specs/openid-financial-api-part-1-1_0.html#authorization-server
+ * FAPI Part 2: https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server
+ *
+ * 
+ */
 
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
 if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id"
@@ -19,27 +30,47 @@ switch(httpMethod.toUpperCase()){
         // Parse incoming registration JWT
         logger.debug(SCRIPT_NAME + "Parsing authorize request")
         def authRequestJwt
-        
-        def requestQueryParam = getQueryParamFromRequest("request")
-        if(!requestQueryParam){
-            return errorResponseFactory.invalidRedirectUriErrorResponse(SCRIPT_NAME)
-        } else {
-            logger.debug(SCRIPT_NAME + " requestQueryParam is " + requestQueryParam[0])
+
+        // From the OAuth 2.0 Spec:
+        // If the request fails due to a missing, invalid, or mismatching
+        // redirection URI, or if the client identifier is missing or invalid,
+        // the authorization server SHOULD inform the resource owner of the
+        // error and MUST NOT automatically redirect the user-agent to the
+        // invalid redirection URI.
+        // From the FAPI Part 1 Spec:
+        // shall only use the parameters included in the signed request object passed via the request or request_uri parameter
+        def reqeustJwt = getRequestJtw()
+        if(!requestJwt) {
+            return createBadRequestResponse("Request must have a 'request' query parameter the value of which must be a signed jwt")
         }
 
-        try {
-            authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam, SignedJwt.class)
-        } catch (e) {
-            logger.warn(SCRIPT_NAME + "Badly formed request jwt: failed to decode registration request JWT", e)
-            return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")
+        def errorMessage = isRequestValidForRedirection(requestJwt)
+        if(errorMessage != null){
+            return createBadRequestResponse(errorMessage)
         }
-        def authRequestClaims = authRequestJwt.getClaimsSet()
 
-        def scopes = authRequestClaims.getClaim("scope")
-        if (!scopes){
-            logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
-            return redirectWithError("Badly formed request jwt: must contain scope claim")
-        }
+        // // If we can validate the redirect_uris then any 
+
+        // def requestQueryParam = getQueryParamFromRequest("request")
+        // if(!requestQueryParam){
+        //     return errorResponseFactory.invalidRedirectUriErrorResponse(SCRIPT_NAME)
+        // } else {
+        //     logger.debug(SCRIPT_NAME + " requestQueryParam is " + requestQueryParam[0])
+        // }
+
+        // try {
+        //     authRequestJwt = new JwtReconstruction().reconstructJwt(requestQueryParam, SignedJwt.class)
+        // } catch (e) {
+        //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: failed to decode registration request JWT", e)
+        //     return errorResponseFactory.invalidClientMetadataErrorResponse("registration request object is not a valid JWT")
+        // }
+        // def authRequestClaims = authRequestJwt.getClaimsSet()
+
+        // def scopes = authRequestClaims.getClaim("scope")
+        // if (!scopes){
+        //     logger.warn(SCRIPT_NAME + "Badly formed request jwt: Request object has not script claim")
+        //     return redirectWithError("Badly formed request jwt: must contain scope claim")
+        // }
     default:
         logger.debug(SCRIPT_NAME + "Method not supported")
         return new Response(Status.NOT_FOUND)
@@ -47,34 +78,72 @@ switch(httpMethod.toUpperCase()){
 
 return next.handle(context, request)
 
-private Response redirectWithError(errorString) {
-    def redirect_uri = getQueryParamFromRequest("redirect_uri")
-    def state = getQueryParamFromRequest("state")
-    if (!state){
-        redirect_uri = redirect_uri + "?error=" + "invalid_scope" + "&error_description=" + errorString
-    } else {
-        redirect_uri = redirect_uri + "?error=" + "invalid_scope" + "&error_description=" + errorString + "&state=" + state
-    }
-    def response = new Response(Status.FOUND)
-    logger.debug(SCRIPT_NAME + " redirect_url is " + url)
-    response.getHeaders().add("Location", redirect_uri)
-    return response
+
+private Response createBadRequestResponse(errorMessage){
+    def badRequestResponse = new Response(Status.BAD_REQUEST)
+    badRequestResponse.setEntity(errorMessage)
+    return badRequestResponse
 }
 
-/*
+private String isRequestValidForRedirection(requestJwt) {
+    def requestJwtClaims = requestJwt.getClaimsSet()
+    def redirectUri = requestJwtClaims.getClaim("redirect_uri")
+
+    if(!redirectUri){
+        return "The request JWT has no or redirect_uri claim"
+    }
+
+    if(!requestJwtClaims.getClaim("client_id")){
+        return "The request JWT has no or client_id claim"
+    }
+
+    return null
+}
+
+private JwtReconstruction getRequestJtw() {
+    def requestJwtString  = getQueryParamFromrequest("request")
+    if (!requestJwtString){
+        logger.info(SCRIPT_NAME + "BAD_REQUEST: /authorize request must have a request query parameter")
+        return null
+    }
+    try{
+        return new JwtReconstruction().reconstructJwt(requestJwtString, SignedJwt.class)
+    catch (e){
+        logger.info(SCRIPT_NAME + "BAD_REQUEST: Could not parse request JWT string", e)
+        return null
+    }
+}
+
+// private Response redirectWithError(errorString) {
+//     def redirect_uri = getQueryParamFromRequest("redirect_uri")
+
+//     def state = getQueryParamFromRequest("state")
+//     if (!state){
+//         redirect_uri = redirect_uri + "?error=" + "invalid_scope" + "&error_description=" + errorString
+//     } else {
+//         redirect_uri = redirect_uri + "?error=" + "invalid_scope" + "&error_description=" + errorString + "&state=" + state
+//     }
+//     def response = new Response(Status.FOUND)
+//     logger.debug(SCRIPT_NAME + " redirect_url is " + url)
+//     response.getHeaders().add("Location", redirect_uri)
+//     return response
+// }
+
+/**
  *  Returns null if the parameter does not exist. Throws IllegalStateException if more than one query parameter with this name exists 
-*/
+ */
 private String getQueryParamFromRequest(paramName) {
     def value = request.getQueryParams().get(paramName)
+
     if ( !value ) {
         logger.info(SCRIPT_NAME + "No query parameter of name " + paramName + " exists in the request")
         return null
-    } else {
-        if ( value.size != 1 ) {
-            logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
-            return null
-        } else (
-            return value[0]
-        )
     }
+
+    if ( value.size != 1 ) {
+        logger.info(SCRIPT_NAME + "There are " + value.size + " values for request parameter " + paramName)
+        return null
+    } 
+    
+    return value
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiCompliantAuthorizeRequestFilter.groovy
@@ -27,18 +27,20 @@ def httpMethod = request.method
 
 switch (httpMethod.toUpperCase()) {
     case 'GET':
+    case 'POST':
         // Parse incoming registration JWT
         logger.debug(SCRIPT_NAME + 'Parsing authorize request')
 
         // From the OAuth 2.0 Spec:
-        // If the request fails due to a missing, invalid, or mismatching
-        // redirection URI, or if the client identifier is missing or invalid,
-        // the authorization server SHOULD inform the resource owner of the
-        // error and MUST NOT automatically redirect the user-agent to the
-        // invalid redirection URI.
+        //   If the request fails due to a missing, invalid, or mismatching
+        //   redirection URI, or if the client identifier is missing or invalid,
+        //   the authorization server SHOULD inform the resource owner of the
+        //   error and MUST NOT automatically redirect the user-agent to the
+        //   invalid redirection URI.
+        //
         // From the FAPI Part 1 Spec:
-        // Shall only use the parameters included in the signed request object passed via the request or request_uri
-        // parameter
+        //   Shall only use the parameters included in the signed request object passed via the request or request_uri
+        //   parameter
         def requestJwt = getRequestJtw()
         if (!requestJwt) {
             return createBadRequestResponse("Request must have a 'request' query parameter the value of which must be "
@@ -47,10 +49,10 @@ switch (httpMethod.toUpperCase()) {
 
         def errorMessage = isRequestValidForRedirection(requestJwt)
         if (errorMessage != null) {
+            logger.info(SCRIPT_NAME + errorMessage)
             return createBadRequestResponse(errorMessage)
         }
 
-        // // If we can validate the redirect_uris then any
 
         // def requestQueryParam = getQueryParamFromRequest("request")
         // if(!requestQueryParam){
@@ -78,6 +80,7 @@ switch (httpMethod.toUpperCase()) {
         return new Response(Status.NOT_FOUND)
 }
 
+logger.info("Request is FAPI compliant - calling next.handle")
 return next.handle(context, request)
 
 private Response createBadRequestResponse(errorMessage) {

--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -10,4 +10,4 @@ USER root
 
 RUN sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list
 
-RUN apt-get update && apt-get install nano
+RUN apt-get update && apt-get install nano vim

--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -10,4 +10,4 @@ USER root
 
 RUN sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list
 
-RUN apt-get update && apt-get install nano vim
+RUN apt-get update && apt-get install nano && apt-get install vim

--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -10,4 +10,4 @@ USER root
 
 RUN sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list
 
-RUN apt-get update && apt-get install nano && apt-get install vim
+RUN apt-get update && apt-get install nano


### PR DESCRIPTION
Fixes for failures when running the fapi1-advanced-final conformance suite tests.

There are some issues with the validation of our request object

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/676