### PR TITLE
811: Use correct DCR error response field names

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/common/exceptions/DCRException.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/common/exceptions/DCRException.java
@@ -51,7 +51,7 @@ public class DCRException extends Exception {
 
     public Map<String, String> getErrorFields(){
         LinkedHashMap<String, String> fields = new LinkedHashMap<>();
-        fields.put("error_code", errorCode.getCode());
+        fields.put("error", errorCode.getCode());
         fields.put("error_description", errorDescription);
         return fields;
     };

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/sigvalidation/RegistrationRequestJwtSignatureValidationService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/sigvalidation/RegistrationRequestJwtSignatureValidationService.java
@@ -82,7 +82,7 @@ public class RegistrationRequestJwtSignatureValidationService {
                 jwtSignatureValidator.validateSignature(registrationRequest.getSignedJwt(), jwks);
                 return Promises.newResultPromise(new Response(Status.OK));
             } catch (SignatureException e) {
-                String errorDescription = "Registration Request signature is invalid";
+                String errorDescription = "Registration Request signature is invalid: '" + e.getMessage() + "'";
                 log.info("({}) {}", fapiInteractionId, errorDescription, e);
                 return Promises.newExceptionPromise(
                         new DCRSignatureValidationException(DCRErrorCode.INVALID_CLIENT_METADATA, errorDescription));


### PR DESCRIPTION
The DCR tests are failing because the field name error_code should be just 'error'.

Issue: https://github.com/secureapigateway/secureapigateway/issues/811