### PR TITLE
782: Changes to support MTLS subdomain

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -43,7 +43,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "&{ig.fqdn}"
+                "&{mtls.fqdn}"
               ]
             }
           }
@@ -56,8 +56,8 @@
             "type": "application/x-groovy",
             "file": "ProcessRs.groovy",
             "args": {
-              "rsResponsePathToReplace": "&{ig.fqdn}",
-              "igPathReplacement": "&{ig.fqdn}/rs"
+              "rsResponsePathToReplace": "&{mtls.fqdn}",
+              "igPathReplacement": "&{mtls.fqdn}/rs"
             }
           }
         }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -17,7 +17,10 @@
             "type": "application/x-groovy",
             "file": "ASWellKnownFilter.groovy",
             "args": {
-              "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}"
+              "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
+              "mtlsEndpoints": ["registration_endpoint", "token_endpoint"],
+              "igHost": "&{ig.fqdn}",
+              "mtlsHost": "&{mtls.fqdn}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ASWellKnownFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ASWellKnownFilter.groovy
@@ -9,6 +9,12 @@ next.handle(context, request).thenOnResult(response -> {
         wellKnownData = response.entity.getJson()
         // Configure auth methods supported using filter arg: tokenEndpointAuthMethodsSupported
         wellKnownData["token_endpoint_auth_methods_supported"] = tokenEndpointAuthMethodsSupported
+
+        // Update endpoints defined in mtlsEndpoints arg to use the mtls host
+        mtlsEndpoints.each { endpoint ->
+            wellKnownData[endpoint] = wellKnownData[endpoint].replace(igHost, mtlsHost)
+        }
+
         response.entity.setJson(wellKnownData)
     }
 })


### PR DESCRIPTION
Applying multiple gateway changes for the MTLS epic in this PR

**838: Updating AS .well-known response to use the mtls hostname for endpoints which require OB mtls**

Added mtlsEndpoints configuration to the route, currently the registration_endpoint and token_endpoint are configured for mtls.

Updated to filter to update the .well-known response to replace the IG hostname with the MTLS hostname for the configured endpoints

**842: Updating RS metadata route to use the mtls hostname**

All calls to RS require MTLS.

Changing the X-Forwarded-Host to use the MTLS host so that RS generates the links correctly.

https://github.com/SecureApiGateway/SecureApiGateway/issues/838
https://github.com/SecureApiGateway/SecureApiGateway/issues/842
https://github.com/SecureApiGateway/SecureApiGateway/issues/782