### PR TITLE
691: Fixing ProcessDetachedSig header claim: http://openbanking.org.uk/iss validation

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoder.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoder.java
@@ -58,9 +58,8 @@ public class IdmApiClientDecoder {
                     }));
 
             apiClient.setOrganisation(apiClientJson.get("apiClientOrg").as(this::requiredField).as(org -> {
-                final JsonValue orgJson = JsonValue.json(org);
-                final String orgId = orgJson.get("id").asString();
-                final String orgName = orgJson.get("name").asString();
+                final String orgId = org.get("id").as(this::requiredField).asString();
+                final String orgName = org.get("name").as(this::requiredField).asString();
                 return new ApiClientOrganisation(orgId, orgName);
             }));
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientService.java
@@ -60,7 +60,7 @@ public class IdmApiClientService implements ApiClientService {
         Reject.ifBlank("clientId must be provided");
         try {
             final Request getApiClientRequest = new Request().setMethod("GET")
-                                                             .setUri(idmGetApiClientBaseUri + clientId + "?_fields=apiClientOrg,*");
+                                                             .setUri(idmGetApiClientBaseUri + clientId + "?_fields=apiClientOrg/*,*");
             return httpClient.send(getApiClientRequest)
                     .thenAsync(response -> {
                         if (!response.getStatus().isSuccessful()) {

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoderTest.java
@@ -120,11 +120,17 @@ public class IdmApiClientDecoderTest {
                 () -> idmApiClientDecoder.decode(json(object())));
         assertEquals("/name: is a required field, failed to decode IDM ApiClient", decodeException.getMessage());
 
+        // Test with ssa field missing
         final JsonValue missingSsaField = createIdmApiClientDataRequiredFieldsOnly("123454");
         missingSsaField.remove("ssa");
-
         decodeException = assertThrows(JsonValueException.class, () -> idmApiClientDecoder.decode(missingSsaField));
         assertEquals("/ssa: is a required field, failed to decode IDM ApiClient", decodeException.getMessage());
+
+        // Test with apiClientOrg.id field missing
+        final JsonValue missingOrgId = createIdmApiClientDataRequiredFieldsOnly("2323");
+        missingOrgId.get("apiClientOrg").remove("id");
+        decodeException = assertThrows(JsonValueException.class, () -> idmApiClientDecoder.decode(missingOrgId));
+        assertEquals("/apiClientOrg/id: is a required field, failed to decode IDM ApiClient", decodeException.getMessage());
     }
 
     @Test

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientServiceTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientServiceTest.java
@@ -104,7 +104,7 @@ public class IdmApiClientServiceTest {
         final Exception exception = assertThrows(Exception.class, () -> apiClientPromise.getOrThrow(1, TimeUnit.MILLISECONDS));
 
         assertEquals("java.net.URISyntaxException: Illegal character in scheme name at index 0:" +
-                " 999://localhost/openidm/managed/9999?_fields=apiClientOrg,*", exception.getMessage());
+                " 999://localhost/openidm/managed/9999?_fields=apiClientOrg/*,*", exception.getMessage());
     }
 
     /**


### PR DESCRIPTION
http://openbanking.org.uk/iss header claim is validated to check it matches "{{org-id}}/{{software-statement-id}}"

To do this we need to get the ApiClient data, as the ProcessDetachedSig filter runs after FetchApiClientFilter then this data is available in the attributes context.

Fixing bug in IDM query which was not retrieiving the fields within the apiClientOrg object.

Fixing bug in ProcessDetachedSig which caused validation errors to be ignored as the isJwsSignatureValid was returning a Promise wrapping a boolean instead of a boolean.

https://github.com/SecureApiGateway/SecureApiGateway/issues/691