### PR TITLE
864: Perform redirect_uri checks in ProcessRegistration

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacade.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacade.java
@@ -17,6 +17,7 @@ package com.forgerock.sapi.gateway.common.jwt;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -114,6 +115,34 @@ public class ClaimsSetFacade {
             }
         } catch (ClassCastException exception) {
             throw new JwtException("Jwt claim '" + claimName + "' is not a List of Strings");
+        }
+    }
+
+    public List<URL> getRequiredUriListClaim(String claimName) throws JwtException {
+        checkClaimName(claimName);
+        try {
+            JsonValue claimValue = this.claimsSet.get(claimName);
+            if (claimValue.getObject() == null) {
+                throw new JwtException("claim of name " + claimName + " must exist in the JWT");
+            }
+            if (claimValue.isList()){
+                List<Object> claimValueList = claimValue.asList();
+                List<URL> uriList = new ArrayList<>(claimValueList.size());
+                for(int index = 0; index < claimValueList.size(); index++){
+                    Object claim = claimValueList.get(index);
+                    try {
+                        URL url = new URL((String)claim);
+                        uriList.add(index, url);
+                    } catch (MalformedURLException e) {
+                        throw new JwtException("claim of name '" + claimName + "' is expected to hold valid URLs: " + e.getMessage());
+                    }
+                }
+                return uriList;
+            } else {
+                throw new JwtException("claim of name '" + claimName + "' is not of type List");
+            }
+        } catch (ClassCastException exception) {
+            throw new JwtException("claim of name '" + claimName + "' is not a List of Strings");
         }
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.dcr.models;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,10 +42,12 @@ public class RegistrationRequest extends SapiJwt {
     public static final String REGISTRATION_REQUEST_KEY = "registrationRequest";
 
     private final SoftwareStatement softwareStatement;
+    private final List<URL> redirectUris;
 
     public RegistrationRequest(Builder builder){
         super(builder);
         this.softwareStatement = builder.softwareStatement;
+        this.redirectUris = builder.redirectUris;
     }
 
     public void setResponseTypes(List<String> responseTypes){
@@ -68,6 +71,13 @@ public class RegistrationRequest extends SapiJwt {
     }
 
     /**
+     * @return the redirect urls specified in the registration request
+     */
+    public List<URL> getRedirectUris(){
+        return this.redirectUris;
+    }
+
+    /**
      * Class to build a {@code RegistrationRequest} from the b64 url encoded registration request jwt string.
      */
     public static class Builder extends SapiJwtBuilder {
@@ -75,6 +85,7 @@ public class RegistrationRequest extends SapiJwt {
         private static final Logger log = LoggerFactory.getLogger(Builder.class);
         private final SoftwareStatement.Builder softwareStatementBuilder;
         private SoftwareStatement softwareStatement;
+        private List<URL> redirectUris;
 
         /**
          * Construct a {@code Builder)
@@ -91,7 +102,7 @@ public class RegistrationRequest extends SapiJwt {
         }
 
         /**
-         * Build a {@code RegistrationRequest} from a the b64 encoded string representation of the registration request
+         * Build a {@code RegistrationRequest} from the b64 encoded string representation of the registration request
          * jwt
          * @param transactionId used for logging context and log tracing
          * @param b64EncodedJwtString the b64 encoded jwt string from the registration request body
@@ -117,6 +128,7 @@ public class RegistrationRequest extends SapiJwt {
             String SSA_CLAIM_NAME = "software_statement";
             String b64EncodedSsa = this.claimsSet.getStringClaim(SSA_CLAIM_NAME);
             softwareStatement = softwareStatementBuilder.build(txId, b64EncodedSsa);
+            this.redirectUris = this.claimsSet.getRequiredUriListClaim("redirect_uris");
         }
 
     }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
@@ -16,6 +16,7 @@
 package com.forgerock.sapi.gateway.dcr.models;
 
 import java.net.URL;
+import java.util.List;
 
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
@@ -47,6 +48,8 @@ public class SoftwareStatement extends SapiJwt {
     private final URL jwksUri;
     private final JWKSet jwksSet;
 
+    private final List<URL> redirectUris;
+
 
     /**
      * Constructor takes a builder
@@ -60,6 +63,7 @@ public class SoftwareStatement extends SapiJwt {
         this.hasJwksUri = builder.hasJwksUri;
         this.jwksUri = builder.jwksUri;
         this.jwksSet = builder.jwkSet;
+        this.redirectUris = builder.redirectUris;
         this.trustedDirectoryJwksUrl = builder.trustedDirectoryJwksUrl;
     }
 
@@ -102,13 +106,22 @@ public class SoftwareStatement extends SapiJwt {
     }
 
     /**
-     * @return if hasJwksUri returns fals, then this will return a JWKS that will contain all of the public keys that
+     * @return if hasJwksUri returns false, then this will return a JWKS that will contain all of the public keys that
      * are associated with the software statement. This JWKS can be used to validate all the transport, signing keys
      * and encryption keys that will be used by the ApiClient
      */
     public JWKSet getJwksSet() {
         return jwksSet;
     }
+
+    /**
+     * @return the list of redirect uris registered with the trusted directory as being valid for this software
+     * statement
+     */
+    public List<URL> getRedirectUris() {
+        return this.redirectUris;
+    }
+
 
     /**
      * A builder that may be used to construct a Software Statement
@@ -123,6 +136,7 @@ public class SoftwareStatement extends SapiJwt {
         private URL jwksUri;
         private JWKSet jwkSet;
         private URL trustedDirectoryJwksUrl;
+        private List<URL> redirectUris;
 
         public Builder(TrustedDirectoryService trustedDirectoryService, JwtDecoder jwtDecoder) {
             super(jwtDecoder);
@@ -168,7 +182,7 @@ public class SoftwareStatement extends SapiJwt {
             this.orgId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementOrgIdClaimName());
             this.softwareId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementSoftwareIdClaimName());
             this.trustedDirectoryJwksUrl = trustedDirectory.getDirectoryJwksUri();
-
+            this.redirectUris = claimsSet.getRequiredUriListClaim(trustedDirectory.getSoftwareStatementRedirectUrisClaimName());
         }
 
         private JWKSet getJwkSet(String transactionId)

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -83,4 +83,10 @@ public interface TrustedDirectory {
      * @return the name of the claim in the software statement that holds a unique identifier for the software statement
      */
     String getSoftwareStatementSoftwareIdClaimName();
+
+    /**
+     * @return the name of the claim in the software statement that holds the array of redirect_uris registered for
+     * the software statement
+     */
+    String getSoftwareStatementRedirectUrisClaimName();
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -51,6 +51,8 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
      */
     final static String softwareStatementSoftwareIdClaimName = "software_id";
 
+    final static String softwareStatementRedirectUriClaimName = "software_redirect_uris";
+
     static {
         try {
             jwksUri = new URL("https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks");
@@ -92,5 +94,10 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     @Override
     public String getSoftwareStatementSoftwareIdClaimName() {
         return softwareStatementSoftwareIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementRedirectUrisClaimName() {
+        return softwareStatementRedirectUriClaimName;
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -51,6 +51,8 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      */
     private final static String softwareStatementSoftwareIdClaimName = "software_id";
 
+    private final static String softwareStatementRedirectUrisClaimName = "software_redirect_uris";
+
     /**
      * Constructor
      * @param secureApiGatewayJwksUri The jwks_uri against which SSAs issued by the Secure API Gateway can be
@@ -93,5 +95,10 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     @Override
     public String getSoftwareStatementSoftwareIdClaimName() {
         return softwareStatementSoftwareIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementRedirectUrisClaimName() {
+        return softwareStatementRedirectUrisClaimName;
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacadeTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacadeTest.java
@@ -285,4 +285,68 @@ class ClaimsSetFacadeTest {
         assertThat(responseTypeValues.isPresent()).isTrue();
         assertThat(responseTypeValues.get()).isEqualTo(expectedResponseTypes);
     }
+
+    @Test
+    void success_getRequiredUriList() throws JwtException {
+
+        // Given
+        JwtClaimsSet claimsSet = new JwtClaimsSet(Map.of("response_type", List.of("https://domain1.com/callback", "https://domain2.com/callback")));
+        ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(claimsSet);
+
+        // When
+        List<URL> responseTypes =  claimsSetFacade.getRequiredUriListClaim("response_type");
+
+        // Then
+        assertThat(responseTypes).isNotNull();
+        assertThat(responseTypes.size()).isEqualTo(2);
+        assertThat(responseTypes.get(0).toString()).isEqualTo("https://domain1.com/callback");
+    }
+
+    @Test
+    void fail_getRequiredUriList_NotURLs() {
+
+        // Given
+        JwtClaimsSet claimsSet = new JwtClaimsSet(Map.of("response_type", List.of("hello", "there")));
+        ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(claimsSet);
+
+        // When
+        JwtException exception =  catchThrowableOfType(()->claimsSetFacade.getRequiredUriListClaim("response_type"),
+                JwtException.class);
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getMessage()).contains("claim of name 'response_type' is expected to hold valid URLs:");
+    }
+
+    @Test
+    void fail_getRequiredUriList_NotStrings() {
+
+        // Given
+        JwtClaimsSet claimsSet = new JwtClaimsSet(Map.of("response_type", List.of(1.0f, 3.2f)));
+        ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(claimsSet);
+
+        // When
+        JwtException exception =  catchThrowableOfType(()->claimsSetFacade.getRequiredUriListClaim("response_type"),
+                JwtException.class);
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getMessage()).contains("claim of name 'response_type' is not a List of Strings");
+    }
+
+    @Test
+    void fail_getRequiredUriList_NotList() {
+
+        // Given
+        JwtClaimsSet claimsSet = new JwtClaimsSet(Map.of("response_type", "https://doamin1.com/callback"));
+        ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(claimsSet);
+
+        // When
+        JwtException exception =  catchThrowableOfType(()->claimsSetFacade.getRequiredUriListClaim("response_type"),
+                JwtException.class);
+
+        // Then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getMessage()).contains("claim of name 'response_type' is not of type List");
+    }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequestBuilderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequestBuilderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 
 import org.forgerock.json.jose.jws.SignedJwt;
@@ -58,7 +59,8 @@ class RegistrationRequestBuilderTest {
     void success_build() throws JwtException, DCRRegistrationRequestBuilderException {
         // Given
         String softwareStatementb64EncodedString = "header.payload.sig";
-        Map<String, Object> claims = Map.of("iss", "Acme App", "software_statement", softwareStatementb64EncodedString);
+        Map<String, Object> claims = Map.of("iss", "Acme App", "software_statement", softwareStatementb64EncodedString,
+                "redirect_uris", List.of("https://domain1.com/callback"));
         SignedJwt regRequestSignedJwt = CryptoUtils.createSignedJwt(claims, JWSAlgorithm.PS256);
         // When
         when(jwtDecoder.getSignedJwt(B64_ENCODED_REG_REQUEST_JWT)).thenReturn(regRequestSignedJwt);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequestFactory.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 import com.forgerock.sapi.gateway.util.CryptoUtils;
@@ -37,7 +38,7 @@ public class RegistrationRequestFactory {
             throw new RuntimeException(e);
         }
     }
-    public static RegistrationRequest getRegRequestWithJwksUriSoftwareStatement() {
+    public static RegistrationRequest getRegRequestWithJwksUriSoftwareStatement() throws MalformedURLException {
         Map<String, Object> ssaClaims = Map.of();
         SoftwareStatement softwareStatement = mock(SoftwareStatement.class);
         when(softwareStatement.hasJwksUri()).thenReturn(true);
@@ -50,6 +51,7 @@ public class RegistrationRequestFactory {
         RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
         when(registrationRequest.getSoftwareStatement()).thenReturn(softwareStatement);
         when(registrationRequest.getSignedJwt()).thenReturn(CryptoUtils.createSignedJwt(regRequestClaims, JWSAlgorithm.PS256));
+        when(registrationRequest.getRedirectUris()).thenReturn(List.of(new URL("https://domain1.com/callback")));
         return registrationRequest;
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequestTest.java
@@ -56,9 +56,11 @@ public class RegistrationRequestTest {
         Map<String, Object> ssaClaims = Map.of("iss", trustedDirectory.getIssuer(),
                 trustedDirectory.getSoftwareStatementJwksUriClaimName(), "https://jwks_uri.com",
                 trustedDirectory.getSoftwareStatementOrgIdClaimName(), "Acme Ltd",
-                trustedDirectory.getSoftwareStatementSoftwareIdClaimName(), "Acme App");
+                trustedDirectory.getSoftwareStatementSoftwareIdClaimName(), "Acme App",
+                trustedDirectory.getSoftwareStatementRedirectUrisClaimName(), List.of("https://domain1.com/callback"));
         String b64EncodedSsaString = CryptoUtils.createEncodedJwtString(ssaClaims, JWSAlgorithm.PS256);
-        Map<String, Object> regRequestClaims = Map.of("iss", "Acme App", "software_statement", b64EncodedSsaString);
+        Map<String, Object> regRequestClaims = Map.of("iss", "Acme App", "software_statement", b64EncodedSsaString,
+                "redirect_uris", List.of("https://domain1.com/callback"));
         String b64EncodedRegRequestString = CryptoUtils.createEncodedJwtString(regRequestClaims, JWSAlgorithm.PS256);
         return requestBuilder.build(TX_ID, b64EncodedRegRequestString);
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementBuilderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementBuilderTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 import org.forgerock.json.jose.jwk.JWKSet;
@@ -35,8 +36,8 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.common.jwt.JwtException;
 import com.forgerock.sapi.gateway.dcr.common.DCRErrorCode;
-import com.forgerock.sapi.gateway.dcr.sigvalidation.DCRTestHelpers;
 import com.forgerock.sapi.gateway.dcr.request.DCRRegistrationRequestBuilderException;
+import com.forgerock.sapi.gateway.dcr.sigvalidation.DCRTestHelpers;
 import com.forgerock.sapi.gateway.jws.JwtDecoder;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryOpenBankingTest;
@@ -55,6 +56,9 @@ class SoftwareStatementBuilderTest {
     private static final String SOFTWARE_ID ="Acme App";
     private static final String JWKS_URI = "https://jwks.com";
     private static final String SSA_JWT_STRING = "header.payload.sig";
+
+    private static final List<String> REDIRECT_URIS =
+            List.of("https://domain1.io/callback", "https://domain2.io.callback");
 
     public static final String TX_ID = "tx_id";
 
@@ -136,7 +140,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failInvalidJwt_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failInvalidJwt_buildSoftwareStatement() throws JwtException {
         // Given
         SignedJwt ssaJwt = mock(SignedJwt.class);
         JwsHeader ssaHeader = mock(JwsHeader.class);
@@ -157,7 +161,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failNoIssuerClaim_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failNoIssuerClaim_buildSoftwareStatement() throws JwtException {
         // Given
         SignedJwt ssaJwt = mock(SignedJwt.class);
         JwtClaimsSet claimsSet = getValidJwkUriBasedClaims();
@@ -173,7 +177,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failUnrecognisedIssuer_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failUnrecognisedIssuer_buildSoftwareStatement() throws JwtException {
         // Given
         JwsHeader ssaHeader = mock(JwsHeader.class);
         SignedJwt ssaJwt = mock(SignedJwt.class);
@@ -191,7 +195,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failNoOrgId_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failNoOrgId_buildSoftwareStatement() throws JwtException {
         // Given
         JwsHeader ssaHeader = mock(JwsHeader.class);
         SignedJwt ssaJwt = mock(SignedJwt.class);
@@ -212,7 +216,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failNoSoftwareId_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failNoSoftwareId_buildSoftwareStatement() throws JwtException {
         // Given
         String jwtString = "header.payload.sig";
         JwsHeader ssaHeader = mock(JwsHeader.class);
@@ -234,7 +238,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failNoJwksUri_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failNoJwksUri_buildSoftwareStatement() throws JwtException {
         // Given
         String jwtString = "header.payload.sig";
         JwsHeader ssaHeader = mock(JwsHeader.class);
@@ -256,7 +260,7 @@ class SoftwareStatementBuilderTest {
     }
 
     @Test
-    void failNoJwks_buildSoftwareStatement() throws JwtException, DCRRegistrationRequestBuilderException {
+    void failNoJwks_buildSoftwareStatement() throws JwtException {
         // Given
         String jwtString = "header.payload.sig";
         JwsHeader ssaHeader = mock(JwsHeader.class);
@@ -281,7 +285,8 @@ class SoftwareStatementBuilderTest {
         Map<String, Object> claims = Map.of("iss", ISSUER,
                 TRUSTED_DIRECTORY_OPEN_BANKING_TEST.getSoftwareStatementOrgIdClaimName(), ORG_ID,
                 TRUSTED_DIRECTORY_OPEN_BANKING_TEST.getSoftwareStatementSoftwareIdClaimName(), SOFTWARE_ID,
-                TRUSTED_DIRECTORY_OPEN_BANKING_TEST.getSoftwareStatementJwksUriClaimName(), JWKS_URI);
+                TRUSTED_DIRECTORY_OPEN_BANKING_TEST.getSoftwareStatementJwksUriClaimName(), JWKS_URI,
+                TRUSTED_DIRECTORY_OPEN_BANKING_TEST.getSoftwareStatementRedirectUrisClaimName(), REDIRECT_URIS);
         return  new JwtClaimsSet(claims);
     }
 
@@ -289,7 +294,8 @@ class SoftwareStatementBuilderTest {
         Map<String, Object> claims = Map.of("iss", ISSUER,
                 DIRECTORY_SECURE_API_GATEWAY.getSoftwareStatementOrgIdClaimName(), ORG_ID,
                 DIRECTORY_SECURE_API_GATEWAY.getSoftwareStatementSoftwareIdClaimName(), SOFTWARE_ID,
-                DIRECTORY_SECURE_API_GATEWAY.getSoftwareStatementJwksClaimName(),  DCRTestHelpers.getJwksJsonValue());
+                DIRECTORY_SECURE_API_GATEWAY.getSoftwareStatementJwksClaimName(),  DCRTestHelpers.getJwksJsonValue(),
+                DIRECTORY_SECURE_API_GATEWAY.getSoftwareStatementRedirectUrisClaimName(), REDIRECT_URIS);
         return  new JwtClaimsSet(claims);
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/request/RegistrationRequestEntityValidatorFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/request/RegistrationRequestEntityValidatorFilterTest.java
@@ -94,7 +94,8 @@ class RegistrationRequestEntityValidatorFilterTest {
         Request request = new Request();
         request.setMethod("POST");
         Map<String, Object> ssaClaims = Map.of("iss", "test-publisher", "software_jwks", getJwkSetObject(),
-                "org_id", "Acme Inc", "software_id", "Acme Banking App");
+                "org_id", "Acme Inc", "software_id", "Acme Banking App",
+                "software_redirect_uris", List.of("https://domain1.com/callback"));
         // When
         when(reqRequestSupplier.apply(context, request)).thenReturn(createRegistrationRequestWithJwksBasedSSA(ssaClaims));
         Promise<Response, NeverThrowsException> promise = filter.filter(context, request, handler);
@@ -134,7 +135,8 @@ class RegistrationRequestEntityValidatorFilterTest {
         RSASSASigner signer = CryptoUtils.createRSASSASigner();
         // Can make valid JWKS entry!! Grrr
         String ssa = CryptoUtils.createEncodedJwtString(ssaClaims, JWSAlgorithm.PS256);
-        Map<String, Object> regRequestClaims = Map.of("iss", "Acme App", "software_statement", ssa);
+        Map<String, Object> regRequestClaims = Map.of("iss", "Acme App", "software_statement", ssa,
+                "redirect_uris", List.of("https://domain1.com/callback"));
         return CryptoUtils.createEncodedJwtString(regRequestClaims, JWSAlgorithm.PS256);
     }
 
@@ -145,7 +147,8 @@ class RegistrationRequestEntityValidatorFilterTest {
         Request request = new Request();
         request.setMethod("POST");
         Map<String, Object> ssaClaims = Map.of("iss", "OpenBanking Ltd", "software_jwks_endpoint", "https://jwks.com",
-                "org_id", "Acme Inc", "software_id", "Acme Banking App");
+                "org_id", "Acme Inc", "software_id", "Acme Banking App",
+                "software_redirect_uris", List.of("https://domain1.com/callback"));
 
         // When
         when(reqRequestSupplier.apply(context, request)).thenReturn(createRegistrationRequestWithJwksUriBasedSSA(ssaClaims));
@@ -164,7 +167,8 @@ class RegistrationRequestEntityValidatorFilterTest {
     private String createRegistrationRequestWithJwksUriBasedSSA(Map<String, Object> ssaClaims) throws NoSuchAlgorithmException {
         RSASSASigner signer = CryptoUtils.createRSASSASigner();
         String ssa = CryptoUtils.createEncodedJwtString(ssaClaims, JWSAlgorithm.PS256);
-        Map<String, Object> regRequestClaims = Map.of("iss", "Acme App", "software_statement", ssa);
+        Map<String, Object> regRequestClaims = Map.of("iss", "Acme App", "software_statement", ssa,
+                "redirect_uris", List.of("https://domain1.com/callback"));
         String registrationRequest = CryptoUtils.createEncodedJwtString(regRequestClaims, JWSAlgorithm.PS256);
         return registrationRequest;
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTest.java
@@ -15,8 +15,6 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -66,6 +64,11 @@ public class TrustedDirectoryTest {
         @Override
         public String getSoftwareStatementSoftwareIdClaimName() {
             return "softwareIdClaimName";
+        }
+
+        @Override
+        public String getSoftwareStatementRedirectUrisClaimName() {
+            return "software_redirect_uris";
         }
     };
 


### PR DESCRIPTION
As a part of issue #733 I removed the redirect_uri checks from ProcessRegistration, believing that these checks were done in the FAPIAdvancedDCRValidationFilter. However, that is not the case, so re-instating this check in the ProcessRegistration script for now

Issue: https://github.com/secureapigateway/secureapigateway/issues/864