### PR TITLE
671: Adding x-fapi-interaction-id value to MDC

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/logback.xml
+++ b/config/7.1.0/securebanking/ig/config/dev/config/logback.xml
@@ -15,8 +15,14 @@
   -->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %message%n%xException</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                </jsonFormatter>
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
+                <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+            </layout>
         </encoder>
     </appender>
      

--- a/config/7.1.0/securebanking/ig/config/prod/config/logback.xml
+++ b/config/7.1.0/securebanking/ig/config/prod/config/logback.xml
@@ -15,8 +15,14 @@
   -->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %nopex[%thread] %-5level %logger{35} - %message%n%rootException{short}</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                </jsonFormatter>
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
+                <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+            </layout>
         </encoder>
     </appender>
      

--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -8,6 +8,7 @@
     "type": "Chain",
     "config": {
       "filters": [
+        "SBATFapiInteractionFilterChain",
         {
           "comment": "Add x-fapi-interaction-id header if one was not present in the request",
           "name": "FapiInteractionIdFilter",

--- a/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
@@ -1,5 +1,6 @@
 import org.forgerock.services.context.TransactionIdContext
 import org.forgerock.services.TransactionId
+import org.slf4j.MDC
 
 /**
  *  This script sets the TransactionIdContext to be the same value as the x-fapi-interaction-id 
@@ -9,15 +10,32 @@ import org.forgerock.services.TransactionId
  *  x-fapi-interaction-id value returned in a failing request's response headers.
  */
 
-def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
-if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
-SCRIPT_NAME = "[FapiTransactionIdFilter] (" + fapiInteractionId + ") - ";
+FAPI_INTERACTION_ID = "x-fapi-interaction-id"
+def fapiInteractionId = request.getHeaders().getFirst(FAPI_INTERACTION_ID)
+if(fapiInteractionId == null) fapiInteractionId = "No " + FAPI_INTERACTION_ID
+SCRIPT_NAME = "[FapiTransactionIdFilter] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
-String interactionId = request.getHeaders().getFirst("x-fapi-interaction-id");
-if (interactionId != null) {
-    logger.debug(SCRIPT_NAME + "Found x-fapi-interaction-id: " + interactionId + " setting as TransactionId")
-    TransactionIdContext newContext = new TransactionIdContext(context, new TransactionId(interactionId));
-    return next.handle(newContext, request);
+if (fapiInteractionId != null) {
+    logger.debug(SCRIPT_NAME + "Found x-fapi-interaction-id: " + fapiInteractionId + " setting as TransactionId")
+    TransactionIdContext newContext = new TransactionIdContext(context, new TransactionId(fapiInteractionId))
+
+    // Add the x-fapi-interaction-id to the MDC context for logging purposes, ensure the previously set value is restored
+    final String previousMdcFapiInteractionId = MDC.get(FAPI_INTERACTION_ID)
+    MDC.put(FAPI_INTERACTION_ID, fapiInteractionId)
+    try {
+        return next.handle(newContext, request).thenAlways(() -> removeFapiInteractionIdFromMdc(previousMdcFapiInteractionId))
+    } finally {
+        removeFapiInteractionIdFromMdc(previousMdcFapiInteractionId)
+    }
 }
-return next.handle(context, request);
+return next.handle(context, request)
+
+// This idiom has been copied from org.forgerock.openig.filter.MdcRouteIdFilter
+private void removeFapiInteractionIdFromMdc(String previousFapiInteractionId) {
+    if (previousFapiInteractionId == null) {
+        MDC.remove(FAPI_INTERACTION_ID)
+    } else {
+        MDC.put(FAPI_INTERACTION_ID, previousFapiInteractionId)
+    }
+}


### PR DESCRIPTION
Using MDC enables contextual information to be added to all log lines.

- Updating FapiTransactionIdFilter to add x-fapi-interaction-id value to MDC
  - The filter the old MDC context value back once it has finished with a request
    - This idiom comes from the ig filter: MdcRouteIdFilter
- Changing logging config to use JsonLayout which will log the MDC values
  - This layout is better suited to cloud logging
  - Google Log Explorer will now be able to display multi-line log messages
- Adding filter chain: SBATFapiInteractionFilterChain to route: 10-ob-account-consent.json, this chain is at the start of all routes to ensure fapi interaction id and forgerock transaction id are set correctly.

https://github.com/SecureApiGateway/SecureApiGateway/issues/671