### PR TITLE
684: Creating SapiLogAttachedExceptionFilter alias for LogAttachedExceptionFilter

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -162,6 +162,11 @@
               "type": "application/x-groovy",
               "file": "FapiTransactionIdFilter.groovy"
             }
+          },
+          {
+            "comment": "Log any unhandled exceptions, installed after the FapiTransactionIdFilter so that the txId being logged is set to the x-fapi-interaction-id",
+            "name": "SapiLogAttachedExceptionFilter",
+            "type": "SapiLogAttachedExceptionFilter"
           }
         ]
       }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.forgerock.openig.alias.ClassAliasResolver;
 
+import com.forgerock.sapi.gateway.common.exception.SapiLogAttachedExceptionFilterHeaplet;
 import com.forgerock.sapi.gateway.consent.ConsentRequestAccessAuthorisationFilter;
 import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.request.RegistrationRequestEntityValidatorFilter;
@@ -53,6 +54,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("RegistrationRequestEntityValidatorFilter", RegistrationRequestEntityValidatorFilter.class);
         ALIASES.put("ConsentRequestAccessAuthorisationFilter", ConsentRequestAccessAuthorisationFilter.class);
         ALIASES.put("TokenEndpointTransportCertValidationFilter", TokenEndpointTransportCertValidationFilter.class);
+        ALIASES.put("SapiLogAttachedExceptionFilter", SapiLogAttachedExceptionFilterHeaplet.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/exception/SapiLogAttachedExceptionFilterHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/exception/SapiLogAttachedExceptionFilterHeaplet.java
@@ -25,9 +25,8 @@ import org.forgerock.openig.heap.HeapException;
  * For Secure API Gateway we are aliasing this filter as SapiLogAttachedExceptionFilter. We want to control where
  * the filter gets installed in a filter chain.
  *
- * The default installation in the Router causes us to have output which
- * includes an invalid transactionId due to it being before the filter that sets the transactionId for Secure API
- * Gateway.
+ * The default installation in the Router causes us to have output which includes an invalid transactionId due to it
+ * being before the filter that sets the transactionId for Secure API Gateway.
  *
  * The default installation still remains and this will handle any exceptions that are raised in between the 2 filters.
  */

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/exception/SapiLogAttachedExceptionFilterHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/exception/SapiLogAttachedExceptionFilterHeaplet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.common.exception;
+
+import org.forgerock.openig.filter.LogAttachedExceptionFilter;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+
+/**
+ * Heaplet which creates a {@link LogAttachedExceptionFilter}
+ *
+ * For Secure API Gateway we are aliasing this filter as SapiLogAttachedExceptionFilter. We want to control where
+ * the filter gets installed in a filter chain.
+ *
+ * The default installation in the Router causes us to have output which
+ * includes an invalid transactionId due to it being before the filter that sets the transactionId for Secure API
+ * Gateway.
+ *
+ * The default installation still remains and this will handle any exceptions that are raised in between the 2 filters.
+ */
+public class SapiLogAttachedExceptionFilterHeaplet extends GenericHeaplet {
+    @Override
+    public Object create() throws HeapException {
+        return new LogAttachedExceptionFilter();
+    }
+
+    @Override
+    protected String getType() {
+        return "SapiLogAttachedExceptionFilter";
+    }
+}


### PR DESCRIPTION
LogAttachedExceptionFilter does not have a heaplet, in order to control where it gets installed in a filter chain then a heaplet is required to be able to create it in config.

Creating SapiLogAttachedExceptionFilter as an alias of LogAttachedExceptionFilter. Using an alias will prevent issues occurring should IG add their own Heaplet for the filter in future.

Installing the filter after FapiTransactionIdFilter. This means that when it catches an unhandled exception, it will log the x-fapi-interaction-id. Without this change a randomly generated transactionId is logged which makes it impossible to find when searching by x-fapi-interaction-id.

The existing LogAttachedExceptionFilter that IG installs by default will handle any unexpected exceptions that occur between the 2 filters.

https://github.com/SecureApiGateway/SecureApiGateway/issues/684