### PR TITLE
867: Fixing NPE raised by AuditConsent script

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -211,7 +211,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -224,7 +224,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -250,7 +250,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -236,7 +236,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "SBATReverseProxyHandlerIdentityPlatform"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -268,7 +268,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -259,7 +259,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -211,7 +211,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -259,7 +259,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -211,7 +211,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -268,7 +268,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -259,7 +259,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -199,7 +199,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -211,7 +211,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -246,7 +246,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -147,7 +147,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
@@ -11,7 +11,7 @@ SCRIPT_NAME = "[SaveIntentIdOnAttributesContext] (" + fapiInteractionId + ") - "
 logger.debug(SCRIPT_NAME + "Running...")
 
 def intentId = JsonValue.json(Json.readJson(contexts.oauth2.accessToken.info.claims)).get("id_token").get("openbanking_intent_id").get("value").asString()
-logger.error(SCRIPT_NAME + "Intent Id value: " + intentId)
+logger.info(SCRIPT_NAME + "Intent Id value: " + intentId)
 attributes.put('openbanking_intent_id', intentId)
 
 next.handle(context, request)


### PR DESCRIPTION
Payment routes were using the wrong consentIdLocator configuration.

Fixing configuration to find the consentId in the RS response /Data.ConsentId for payment access

Fixing configuration to find consentId in access_token claims for payment submissions and funds confirmation

Minor cleanup to AuditConsent.groovy

https://github.com/SecureApiGateway/SecureApiGateway/issues/867