### PR TITLE
871: Fixing ObResponseCheck to produce valid OBErrorResponse1 response object

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
@@ -98,6 +98,7 @@ next.handle(context, request).thenOnResult({response ->
   Status status = response.getStatus()
   String responseBody = response.getEntity().getString();
 
+  // Build an OBErrorResponse1 response object
   if ((status.isClientError() || status.isServerError()) && !isObCompliantError(responseBody)) {
 
     def code = status.getCode()
@@ -108,31 +109,17 @@ next.handle(context, request).thenOnResult({response ->
     ]
 
     requestIds = request.headers.get("x-request-id")
-
-
     if (requestIds) {
       newBody.put("Id",requestIds.firstValue)
     }
 
     newBody.put("Message",  status.toString())
 
-    Map<String,String> errorList = attributes.obErrors
-
-    if (!errorList) {
-      errorList = getGenericError(status,responseBody)
-    }
-
-    newBody.put("Errors",errorList)
+    def obErrorObject = getGenericError(status, responseBody)
+    errorList = [obErrorObject]
+    newBody.put("Errors", errorList)
     logger.debug(SCRIPT_NAME + "Final Error Response: " + newBody)
     response.setEntity(newBody)
   }
 })
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
The Errors field in OBErrorResponse1 is an array, fixing ObResponseCheck script to produce an array containing a single error.

Fixing the same bug in GetResourceOwnerIdFromConsent script.

New issue raised to review and cleanup the OB error handling in IG:
https://github.com/SecureApiGateway/SecureApiGateway/issues/872


https://github.com/SecureApiGateway/SecureApiGateway/issues/870
https://github.com/SecureApiGateway/SecureApiGateway/issues/871