### PR TITLE
865: Store SSA roles in the ApiClient object

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -167,11 +167,20 @@ def buildApiClientIdmObject(oauth2ClientId, softwareStatement) {
           "apiClientOrg"  : ["_ref": "managed/" + routeArgObjApiClientOrg + "/" + softwareStatement.getOrgId()]
   ]
 
+  StringBuilder sb = new StringBuilder();
+  for(String role: softwareStatement.getRoles()){
+    sb.append(role).append(', ')
+  }
+  sb.deleteCharAt(sb.length() -2)
+  apiClientIdmObj.roles = sb.toString()
+
   if (softwareStatement.hasJwksUri()){
     apiClientIdmObj.jwksUri = softwareStatement.getJwksUri()
   } else {
-    apiClientIdmObj.jwks = JsonOutput.toJson(softwareStatement.getJwksSet())
+    apiClientIdmObj.jwks = softwareStatement.getJwksSet().toJsonValue()
+    logger.debug("jwks is '{}'", apiClientIdmObj)
   }
+
   return apiClientIdmObj
 }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientService.java
@@ -24,6 +24,8 @@ import org.forgerock.json.JsonValue;
 import org.forgerock.util.Reject;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.forgerock.sapi.gateway.dcr.idm.ApiClientService.ApiClientServiceException.ErrorCode;
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
@@ -33,6 +35,7 @@ import com.forgerock.sapi.gateway.dcr.models.ApiClient;
  */
 public class IdmApiClientService implements ApiClientService {
 
+    Logger log = LoggerFactory.getLogger(ApiClientService.class);
     /**
      * The base uri to use in GET requests to IDM to query for the apiClient
      *

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/ApiClientTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/ApiClientTest.java
@@ -19,13 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.json.jose.jws.JwsHeader;
 import org.forgerock.json.jose.jws.SignedJwt;
 import org.forgerock.json.jose.jwt.JwtClaimsSet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
@@ -67,6 +67,8 @@ public class ApiClientTest {
                 .setSoftwareClientId("softwareClientId543")
                 .setSoftwareStatementAssertion(EMPTY_SSA)
                 .setJwksUri(null)
+                .setRoles(List.of("AISP", "PISP", "CBPII"))
+                .setJwks(new JWKSet())
                 .setOrganisation(new ApiClientOrganisation("orgId123", "Test Organisation"));
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientDecoderTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -36,6 +38,7 @@ import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.dcr.sigvalidation.DCRTestHelpers;
 
 public class IdmApiClientDecoderTest {
 
@@ -55,9 +58,11 @@ public class IdmApiClientDecoderTest {
                 field("description", "Blah blah blah"),
                 field("ssa", createTestSoftwareStatementAssertion().build()),
                 field("oauth2ClientId", clientId),
+                field("roles", "AISP, PISP, CBPII"),
+                field("jwks", DCRTestHelpers.getJwksJsonValue()),
                 field("deleted", false),
                 field("apiClientOrg", object(field("id", "98761234"),
-                        field("name", "Test Organisation")))));
+                field("name", "Test Organisation")))));
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientServiceTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/IdmApiClientServiceTest.java
@@ -39,6 +39,7 @@ import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
 import org.junit.jupiter.api.Test;
 
+import com.forgerock.sapi.gateway.common.jwt.JwtException;
 import com.forgerock.sapi.gateway.dcr.idm.ApiClientService.ApiClientServiceException;
 import com.forgerock.sapi.gateway.dcr.idm.ApiClientService.ApiClientServiceException.ErrorCode;
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
@@ -62,7 +63,7 @@ public class IdmApiClientServiceTest {
     }
 
     @Test
-    void testThrowsExceptionIfApiClientHasBeenDeleted() {
+    void testThrowsExceptionIfApiClientHasBeenDeleted() throws JwtException {
         final JsonValue idmClientData = createIdmApiClientDataRequiredFieldsOnly(TEST_CLIENT_ID);
         idmClientData.put("deleted", Boolean.TRUE);
         final MockApiClientTestDataIdmHandler idmResponseHandler = new MockApiClientTestDataIdmHandler(TEST_IDM_BASE_URI, TEST_CLIENT_ID, idmClientData);
@@ -101,7 +102,7 @@ public class IdmApiClientServiceTest {
     }
 
     @Test
-    void testThrowsExceptionWhenIdmReturnsApiClientMissingRequiredFields() {
+    void testThrowsExceptionWhenIdmReturnsApiClientMissingRequiredFields() throws JwtException {
         final JsonValue idmClientData = createIdmApiClientDataRequiredFieldsOnly(TEST_CLIENT_ID);
         idmClientData.remove("ssa"); // Remove the required ssa field
         final MockApiClientTestDataIdmHandler idmResponseHandler = new MockApiClientTestDataIdmHandler(TEST_IDM_BASE_URI, TEST_CLIENT_ID, idmClientData);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementTestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementTestFactory.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.forgerock.json.JsonValue;
 
-import com.forgerock.sapi.gateway.common.jwt.JwtException;
 import com.forgerock.sapi.gateway.dcr.sigvalidation.DCRTestHelpers;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryTestFactory;
@@ -36,11 +35,7 @@ public class SoftwareStatementTestFactory {
     private static final List<String> ROLES = List.of("AISP", "PISP", "CBPII");
 
     static {
-        try {
-            JWKS_SET = DCRTestHelpers.getJwksJsonValue();
-        } catch (JwtException e) {
-            throw new RuntimeException("Failed to getJwksJsonValue", e);
-        }
+        JWKS_SET = DCRTestHelpers.getJwksJsonValue();
     }
 
     public static Map<String, Object> getValidJwksUriBasedSsaClaims(Map<String, Object> overrideSsaClaims){

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/DCRTestHelpers.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/DCRTestHelpers.java
@@ -177,11 +177,15 @@ public class DCRTestHelpers {
      * @return a JsonValue jwks set
      * @throws JwtException when the jwt can't be decoded
      */
-    public static JsonValue getJwksJsonValue() throws JwtException {
+    public static JsonValue getJwksJsonValue() {
         String b64EncodedSSA = DCRTestHelpers.VALID_SSA_FROM_IG;
         JwtDecoder jwtDecoder = new JwtDecoder();
         SignedJwt ssa = null;
-        ssa = jwtDecoder.getSignedJwt(b64EncodedSSA);
+        try {
+            ssa = jwtDecoder.getSignedJwt(b64EncodedSSA);
+        } catch (JwtException e){
+            throw new IllegalArgumentException(e);
+        }
         JwtClaimsSet ssaClaims = ssa.getClaimsSet();
         JsonValue jwks = ssaClaims.get("software_jwks");
         return jwks;


### PR DESCRIPTION
Roles are needed for access decisions, and the roles in the SSA ultimately limit the roles that a client can request and the apis that a client can access. Each API request needs to know which roles were in the Software Statement and limit access accordingly.

Issue: https://github.com/secureapigateway/secureapigateway/issues/865