### PR TITLE
871: Produce valid OBErrorResponse1 json response for OB API errors

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/GetResourceOwnerIdFromConsent.groovy
@@ -56,25 +56,10 @@ def getErrorResponse() {
     logger.error(SCRIPT_NAME + "Message: " + message + ". ErrorCode:" + errorCode)
 
     response = new Response(Status.BAD_REQUEST)
-
-    Map<String,String> newBody = [
-            Code: Status.BAD_REQUEST.toString()
-    ]
-
-    requestIds = request.headers.get("x-request-id")
-    if (requestIds) {
-        newBody.put("Id", requestIds.firstValue)
-    }
-    newBody.put("Message",  Status.BAD_REQUEST.toString())
-
-    Map<String,String> errorList =[
-            ErrorCode: errorCode,
-            Message: message
-    ]
-
-    newBody.put("Errors", errorList)
-    response.setEntity(newBody)
-    return response;
+    response.setEntity(json(object(field("Code", Status.BAD_REQUEST.toString()),
+                                   field("Errors", array(object(field("ErrorCode", errorCode),
+                                                                field("Message", message)))))))
+    return response
 }
 /**
  * End definitions

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
@@ -98,6 +98,7 @@ next.handle(context, request).thenOnResult({response ->
   Status status = response.getStatus()
   String responseBody = response.getEntity().getString();
 
+  // Build an OBErrorResponse1 response object
   if ((status.isClientError() || status.isServerError()) && !isObCompliantError(responseBody)) {
 
     def code = status.getCode()
@@ -108,31 +109,17 @@ next.handle(context, request).thenOnResult({response ->
     ]
 
     requestIds = request.headers.get("x-request-id")
-
-
     if (requestIds) {
       newBody.put("Id",requestIds.firstValue)
     }
 
     newBody.put("Message",  status.toString())
 
-    Map<String,String> errorList = attributes.obErrors
-
-    if (!errorList) {
-      errorList = getGenericError(status,responseBody)
-    }
-
-    newBody.put("Errors",errorList)
+    def obErrorObject = getGenericError(status, responseBody)
+    errorList = [obErrorObject]
+    newBody.put("Errors", errorList)
     logger.debug(SCRIPT_NAME + "Final Error Response: " + newBody)
     response.setEntity(newBody)
   }
 })
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
The Errors field in OBErrorResponse1 is an array, fixing ObResponseCheck script to produce an array containing a single error.

Fixing the same bug in GetResourceOwnerIdFromConsent script.

New issue raised to review and cleanup the OB error handling in IG:
https://github.com/SecureApiGateway/SecureApiGateway/issues/872

https://github.com/SecureApiGateway/SecureApiGateway/issues/870
https://github.com/SecureApiGateway/SecureApiGateway/issues/871