### PR TITLE
875: Setting OB route header: X-Forwarded-Host using config

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -198,7 +198,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -198,7 +198,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -229,7 +229,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -242,7 +242,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -268,7 +268,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -286,7 +286,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -277,7 +277,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -229,7 +229,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -277,7 +277,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -229,7 +229,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -286,7 +286,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -277,7 +277,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -217,7 +217,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -229,7 +229,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -264,7 +264,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -165,7 +165,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "rs.dev.forgerock.financial"
+                "&{mtls.fqdn}"
               ]
             }
           }


### PR DESCRIPTION
Using MTLS_FQDN environment variable to set X-Forwarded-Host header for OB routes; this value is `mtls.sapig.dev.forgerock.financial` for the dev namespace.

https://github.com/SecureApiGateway/SecureApiGateway/issues/875