### PR TITLE
876: Disable message capturing for IDMClientHandler to stop messages being captured twice

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -316,7 +316,6 @@
     {
       "name": "IDMClientHandler",
       "type": "Chain",
-      "capture": "all",
       "config": {
         "filters": [
           {

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -304,7 +304,6 @@
     {
       "name": "IDMClientHandler",
       "type": "Chain",
-      "capture": "all",
       "config": {
         "filters": [
           {


### PR DESCRIPTION
IDMClientHandler is wrapping the ForgeRockClientHandler. Both Handlers have capturing turn on, this means that messages are captured and logged twice. Disabling capturing on the IDMClientHandler.

https://github.com/SecureApiGateway/SecureApiGateway/issues/876