### PR TITLE
878: Fixing ApiClient.toString NPE

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/ApiClient.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/ApiClient.java
@@ -206,10 +206,10 @@ public class ApiClient {
                 ", softwareClientId='" + softwareClientId + '\'' +
                 ", clientName='" + clientName + '\'' +
                 ", jwksUri=" + jwksUri +
-                ", jwks=" + jwks.toJsonValue() +
+                ", jwks=" + jwks +
                 ", softwareStatementAssertion=" + softwareStatementAssertion +
                 ", organisation=" + organisation +
-                ", roles=" + roles.toString() +
+                ", roles=" + roles +
                 ", deleted=" + deleted +
                 '}';
     }


### PR DESCRIPTION
jwks field is allowed to be null, therefore NPE is being thrown when .toJsonValue() is called on it.

Changing ApiClient.toString impl to let the JVM call toString on the individual fields to avoid NPEs. The JWKSet.toString is dumping the output as json.

https://github.com/SecureApiGateway/SecureApiGateway/issues/878