### PR TITLE
877: Updating GitHub actions to produce production mode docker images

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: docker build
         run: |
-          make build-docker-ig tag=${{ env.GIT_SHA_SHORT }}
+          make build-docker-ig tag=${{ env.GIT_SHA_SHORT }} env="prod"
           docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
           docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,10 @@ jobs:
 
       - name: Build Docker Image
         run: |
+          # Create development mode docker image
           make build-docker-ig tag=$PR_NUMBER
+          # Create production mode docker image
+          make build-docker-ig tag="$PR_NUMBER-prod" env="prod"
 
       - name: Create lowercase Github Username
         id: toLowerCase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          make docker tag=${{ github.event.release.tag_name }} gcr-repo=${{ secrets.RELEASE_REPO }}
+          make docker tag=${{ github.event.release.tag_name }} env="prod" gcr-repo=${{ secrets.RELEASE_REPO }}


### PR DESCRIPTION
- Merges now produce production mode images, the latest tag is always production mode from now on
- Releases also produce production mode images (pipeline not currently used)
- PR pipeline produces development + production images
  - The development image will be deployed to the developer's environment, image tag is unchanged
  - The image tagged as $PR_NUMBER-prod is available for manual deployment should the developer wish to test the prod config

https://github.com/SecureApiGateway/SecureApiGateway/issues/877