### PR TITLE
879: Using IG_TEST_DIRECTORY_ENABLED config in production

### DIFF
--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "security": {
-      "enableTestTrustedDirectory": false
+      "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|false}"}
     },
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]

--- a/config/7.1.0/securebanking/ig/routes/routes-service/71-ob-jwkms-apiclient-issuecert.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/71-ob-jwkms-apiclient-issuecert.json
@@ -2,7 +2,7 @@
   "comment": "Test CA - generate TPP WAC and SEAL certificates and private keys",
   "name" : "71 - API Client Onboarding - Create Certs",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/apiclient/issuecert')}",
+  "condition" : "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/apiclient/issuecert')}",
   "handler":     {
     "comment": "Generate certificates and keys, and return as JWK set",
     "name": "JwkmsIssueCert",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -2,7 +2,7 @@
   "comment": "Create SSA for test TPP clients to use in OIDC dynamic registration",
   "name": "72 - API client onboarding - generate test SSA",
   "auditService": "AuditService-OB-Route",
-  "condition": "${matches(request.uri.path, '^/jwkms/apiclient/getssa')}",
+  "condition": "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/apiclient/getssa')}",
   "handler": {
     "type": "Chain",
     "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/73-ob-jwkms-apiclient-signclaims.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/73-ob-jwkms-apiclient-signclaims.json
@@ -2,7 +2,7 @@
   "comment": "Signing service for TPPs with test JWK set",
   "name": "73 - Test TPP signing service",
   "auditService": "AuditService-OB-Route",
-  "condition": "${matches(request.uri.path, '^/jwkms/apiclient/signclaims')}",
+  "condition": "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/apiclient/signclaims')}",
   "heap": [],
   "handler": {
     "type": "Chain",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/74-ob-jwkms-apiclient-get-tls-cert.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/74-ob-jwkms-apiclient-get-tls-cert.json
@@ -2,7 +2,7 @@
   "comment": "Convert incoming JWK set to PEM encoded TLS client cert and key",
   "name" : "74 - API Client Onboarding - Extract TLS Cert",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/apiclient/gettlscert')}",
+  "condition" : "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/apiclient/gettlscert')}",
   "handler":     {
     "name": "JwkmsIssueCert",
     "type": "ScriptableHandler",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-test-directory-jwks.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-test-directory-jwks.json
@@ -2,7 +2,7 @@
   "comment": "Hosts the JWK Set for the Test Directory JWT issuer, used when validating signatures of JWTs produced by the Test Directory",
   "name" : "75 - JWK Set service for Test Directory JWT issuer",
   "auditService": "AuditService-OB-Route",
-  "condition" : "${matches(request.uri.path, '^/jwkms/testdirectory/jwks')}",
+  "condition" : "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/testdirectory/jwks')}",
   "handler":     {
     "name": "JwkSetHandler-TA",
     "type": "JwkSetHandler",


### PR DESCRIPTION
Allow IG_TEST_DIRECTORY_ENABLED env var to configure this feature in production images. This allows us to run a production image in our development environments with this feature enabled.

By default, this feature is turned off.

Adding check to see if the feature is enabled as part of the jwkms routes which form part of the Test Trusted Directory functionality. Currently, the feature check is only done in the DCR route which prevents someone from using data issued by the directory.

https://github.com/SecureApiGateway/SecureApiGateway/issues/879