### PR TITLE
874: Fixing x-ob-url header passed downstream to use mtls domain

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -205,9 +205,10 @@
             "type": "HeaderFilter",
             "config": {
               "messageType": "REQUEST",
+              "remove": ["x-ob-url"],
               "add": {
                 "x-ob-url": [
-                  "https://&{ig.fqdn}${contexts.router.remainingUri}"
+                  "https://&{mtls.fqdn}${contexts.router.remainingUri}"
                 ]
               }
             }

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -193,9 +193,10 @@
             "type": "HeaderFilter",
             "config": {
               "messageType": "REQUEST",
+              "remove": ["x-ob-url"],
               "add": {
                 "x-ob-url": [
-                  "https://&{ig.fqdn}${contexts.router.remainingUri}"
+                  "https://&{mtls.fqdn}${contexts.router.remainingUri}"
                 ]
               }
             }


### PR DESCRIPTION
The `x-ob-url` header is used to build links in Open Banking responses for the Accounts APIs, the header is currently being set incorrectly by IG.

Changes implemented:
- Clearing any x-ob-url header sent from the client
- Setting x-ob-url to use the mtls domain

This will fix the self links built by the RS for APIs that use the `x-ob-url` header. Other APIs, such as Payments, need further investigation.

https://github.com/SecureApiGateway/SecureApiGateway/issues/874