### PR TITLE
874: Adding X-Forwarded-Prefix header to RS RP requests

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -39,11 +39,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }
@@ -54,11 +58,7 @@
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ProcessRs.groovy",
-            "args": {
-              "rsResponsePathToReplace": "&{mtls.fqdn}",
-              "igPathReplacement": "&{mtls.fqdn}/rs"
-            }
+            "file": "ProcessRs.groovy"
           }
         }
       ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -194,11 +194,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -194,11 +194,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -225,11 +225,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -238,11 +238,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -264,11 +264,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -282,11 +282,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -273,11 +273,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -225,11 +225,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -273,11 +273,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -225,11 +225,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -282,11 +282,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -273,11 +273,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -213,11 +213,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -225,11 +225,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -260,11 +260,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -161,11 +161,15 @@
             "messageType": "REQUEST",
             "remove": [
               "host",
-              "X-Forwarded-Host"
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
             ],
             "add": {
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRs.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRs.groovy
@@ -7,9 +7,6 @@ SCRIPT_NAME = "[ProcessRs] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 next.handle(context, request).thenOnResult(response -> {
-    // Replace the configurable rsResponsePathToReplace with the igPathReplacement, this makes the API path externally callable.
-    response.entity = response.entity.getString().replace(rsResponsePathToReplace, igPathReplacement)
-
     try {
         JsonValue newEntity = response.entity.getJson();
 


### PR DESCRIPTION
X-Forwarded-Prefix is used to contain a baseUri that exists on the gateway/ingress that has been removed when calling the upstream service (RS).

This fixes an issue with the Payments API links being generated by the RS being incorrect (missing the /rs path prefix). Spring HATEOAS impl uses the X-Forwarded-Host and X-Forwarded-Prefix headers when building a self link.

This change removes the needs to add the prefix in manually as part of the RS discovery response post-processing, which cleans up the ProcessRs script and route.

https://github.com/SecureApiGateway/SecureApiGateway/issues/874