### PR TITLE
859: Removing ParseCertificate script from routes that no longer require it

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -24,18 +24,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -22,18 +22,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Remove /rs base path for downstream RS",
           "type": "UriPathRewriteFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -22,18 +22,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Remove /rs base path for downstream RS",
           "type": "UriPathRewriteFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -40,18 +40,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -45,18 +45,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -40,18 +40,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -40,18 +40,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -35,18 +35,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -54,18 +54,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -36,18 +36,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -40,18 +40,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -41,18 +41,6 @@
           }
         },
         {
-          "comment": "Extract client certificate details",
-          "name": "ParseCertificate",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ParseCertificate.groovy",
-            "args": {
-              "routeArgCertificateHeader": "ssl-client-cert"
-            }
-          }
-        },
-        {
           "comment": "Extract client certificate thumbprint for cert bound access tokens",
           "name": "CertificateThumbprintFilter-1",
           "type": "CertificateThumbprintFilter",

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
@@ -1,21 +1,7 @@
 import java.security.cert.Certificate
 import java.security.cert.CertificateFactory
-import java.net.URLDecoder
 import javax.naming.ldap.LdapName
 import javax.naming.ldap.Rdn
-import org.bouncycastle.asn1.ASN1InputStream
-import org.bouncycastle.asn1.ASN1Sequence
-import org.bouncycastle.asn1.ASN1ObjectIdentifier
-import org.bouncycastle.asn1.ASN1Primitive
-import org.bouncycastle.asn1.DEROctetString
-import javax.crypto.Cipher;
-import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.SecretKey;
-import org.bouncycastle.asn1.ASN1OctetString
-import java.security.KeyFactory
-import java.security.PrivateKey
-import java.security.spec.PKCS8EncodedKeySpec
-import java.security.interfaces.RSAPublicKey;
 
 
 /*
@@ -29,47 +15,11 @@ SCRIPT_NAME = "[ParseCertificate] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 class CertificateParserHelper {
-    private static final EXTENDED_KEY_USAGE_OID_STRINGS = [
-            "2.5.29.37.0",
-            "1.3.6.1.5.5.7.3.0",
-            "1.3.6.1.5.5.7.3.1",
-            "1.3.6.1.5.5.7.3.2",
-            "1.3.6.1.5.5.7.3.3",
-            "1.3.6.1.5.5.7.3.4",
-            "1.3.6.1.5.5.7.3.5",
-            "1.3.6.1.5.5.7.3.6",
-            "1.3.6.1.5.5.7.3.7",
-            "1.3.6.1.5.5.7.3.8",
-            "1.3.6.1.4.1.311.20.2.2",
-            "1.3.6.1.5.5.7.3.9"
-    ];
-
-    private static final EXTENDED_KEY_USAGE_TEXTS = [
-            "All Usages",
-            "All Usages",
-            "Server Authentication",
-            "Client Authentication",
-            "Code Signing",
-            "Email Protection",
-            "IPSec end system",
-            "IPSec tunnel",
-            "IPSec user",
-            "Timestamping",
-            "Smartcard Logon",
-            "OCSP signer"
-    ];
-
-    private static final OID_QC_STATEMENTS = "1.3.6.1.5.5.7.1.3"
-
-    private static final OID_PSD2_QC_STATEMENT = "0.4.0.19495.2"
-
     private static final OID_ORGANIZATIONAL_IDENTIFIER = "2.5.4.97"
     private static final TYPE_ORGANIZATIONAL_IDENTIFIER = "OI"
 
     public static parseDN(String dn) {
         def result = [:]
-
-
         LdapName ln = new LdapName(dn);
 
         for(Rdn rdn : ln.getRdns()) {
@@ -80,8 +30,6 @@ class CertificateParserHelper {
             }
             result.put(rdnType,rdn.getValue());
         }
-
-
         return result;
     }
 }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ParseCertificate.groovy
@@ -66,158 +66,23 @@ class CertificateParserHelper {
     private static final OID_ORGANIZATIONAL_IDENTIFIER = "2.5.4.97"
     private static final TYPE_ORGANIZATIONAL_IDENTIFIER = "OI"
 
-
-    public static List<String> getExtendedKeyUsageAsText(Certificate certificate) {
-      def extendedKeyUsageOidToTextMap = [EXTENDED_KEY_USAGE_OID_STRINGS, EXTENDED_KEY_USAGE_TEXTS].transpose().collectEntries{it}
-      try {
-        def extendedkeyusage = certificate.getExtendedKeyUsage();
-        if (extendedkeyusage == null){
-          return [];
-        }
-        def returnval = []
-        extendedkeyusage.each{it->
-          returnval.push(extendedKeyUsageOidToTextMap.get(it));
-        }
-        return returnval;
-      } catch (java.security.cert.CertificateParsingException e) {
-        //log.error("certificate parsing exception" + e.getLocalizedMessage(), e);
-        throw e;
-      }
-    }
-
-
     public static parseDN(String dn) {
-      def result = [:]
+        def result = [:]
 
 
-      LdapName ln = new LdapName(dn);
+        LdapName ln = new LdapName(dn);
 
-      for(Rdn rdn : ln.getRdns()) {
-          def rdnType = rdn.getType();
-          // LdapName doesn't know about OrganizationalIdentifier
-          if (rdnType == ("OID." + OID_ORGANIZATIONAL_IDENTIFIER)) {
-              rdnType = TYPE_ORGANIZATIONAL_IDENTIFIER
-          }
-        result.put(rdnType,rdn.getValue());
-      }
-
-
-      return result;
-    }
-
-    public static getSubjectAltName(Certificate certificate) {
-      def result=[]
-      def sans = certificate.getSubjectAlternativeNames()
-      try {
-        if ( sans!= null) {
-          sans.each {iter->
-            String name = (String)iter.get(1);
-            if (name != null){
-              result.push(name);
+        for(Rdn rdn : ln.getRdns()) {
+            def rdnType = rdn.getType();
+            // LdapName doesn't know about OrganizationalIdentifier
+            if (rdnType == ("OID." + OID_ORGANIZATIONAL_IDENTIFIER)) {
+                rdnType = TYPE_ORGANIZATIONAL_IDENTIFIER
             }
-          }
-        }
-      } catch (java.security.cert.CertificateParsingException e) {
-        result = e.getMessage();
-      }
-
-      return result;
-    }
-
-    /*
-     * getRoles() - pull the list of roles from the QCStatements extension
-     *
-     * Example extension content:
-
-       0:d=0  hl=3 l= 203 cons: SEQUENCE
-       3:d=1  hl=2 l=   8 cons:  SEQUENCE
-       5:d=2  hl=2 l=   6 prim:   OBJECT            :0.4.0.1862.1.1
-      13:d=1  hl=2 l=  19 cons:  SEQUENCE
-      15:d=2  hl=2 l=   6 prim:   OBJECT            :0.4.0.1862.1.6
-      23:d=2  hl=2 l=   9 cons:   SEQUENCE
-      25:d=3  hl=2 l=   7 prim:    OBJECT            :0.4.0.1862.1.6.3
-      34:d=1  hl=2 l=   9 cons:  SEQUENCE
-      36:d=2  hl=2 l=   7 prim:   OBJECT            :0.4.0.194121.1.2
-      45:d=1  hl=3 l= 158 cons:  SEQUENCE
-      48:d=2  hl=2 l=   6 prim:   OBJECT            :0.4.0.19495.2
-      56:d=2  hl=3 l= 147 cons:   SEQUENCE
-      59:d=3  hl=2 l= 106 cons:    SEQUENCE
-      61:d=4  hl=2 l=  41 cons:     SEQUENCE
-      63:d=5  hl=2 l=   7 prim:      OBJECT            :0.4.0.19495.1.4
-      72:d=5  hl=2 l=  30 prim:      UTF8STRING        :Card Based Payment Instruments
-     104:d=4  hl=2 l=  30 cons:     SEQUENCE
-     106:d=5  hl=2 l=   7 prim:      OBJECT            :0.4.0.19495.1.3
-     115:d=5  hl=2 l=  19 prim:      UTF8STRING        :Account Information
-     136:d=4  hl=2 l=  29 cons:     SEQUENCE
-     138:d=5  hl=2 l=   7 prim:      OBJECT            :0.4.0.19495.1.2
-     147:d=5  hl=2 l=  18 prim:      UTF8STRING        :Payment Initiation
-     167:d=3  hl=2 l=  29 prim:    UTF8STRING        :ForgeRock Financial Authority
-     198:d=3  hl=2 l=   6 prim:    UTF8STRING        :GB-FFA
-     206:d=0  hl=2 l=  13 cons: SEQUENCE
-     208:d=1  hl=2 l=   9 prim:  OBJECT            :sha256WithRSAEncryption
-     219:d=1  hl=2 l=   0 prim:  NULL
-     221:d=0  hl=4 l= 257 prim: BIT STRING
-
-    */
-
-
-    public static getRoles(Certificate certificate, loghandler) {
-        def roles = []
-
-        byte[] qcBytes = certificate.getExtensionValue(OID_QC_STATEMENTS)
-
-        if (qcBytes == null) {
-            loghandler.warn("No QC statement")
-            return null
+            result.put(rdnType,rdn.getValue());
         }
 
-        ASN1InputStream asn1InputStream = new ASN1InputStream(qcBytes)
-        ASN1Primitive derObject = asn1InputStream.readObject();
 
-        if (!(derObject instanceof DEROctetString) ) {
-            loghandler.warn("Can't get octet string from " + derObject.toString())
-            return null
-        }
-
-        asn1InputStream = new ASN1InputStream(derObject.getOctets())
-        ASN1Primitive baseSequence = asn1InputStream.readObject();
-
-        if (!(baseSequence instanceof ASN1Sequence)) {
-            loghandler.warn("Can't get base asn1 sequence from " + baseSequence.toString())
-            return null
-        }
-
-        loghandler.debug("Parsing roles from " + baseSequence)
-
-
-        def objects = baseSequence.getObjects()
-
-        while (objects.hasMoreElements()) {
-            def seq = objects.nextElement();
-            if (seq instanceof ASN1Sequence) {
-                def obj = seq.getObjectAt(0)
-                if (obj && obj instanceof ASN1ObjectIdentifier && obj.getId() == OID_PSD2_QC_STATEMENT) {
-                    def seq1 = seq.getObjectAt(1)
-                    if (seq1) {
-                        def seq2 = seq1.getObjectAt(0)
-                        if (seq2 instanceof ASN1Sequence) {
-                            def rolesSeq = seq2.getObjects()
-                            while (rolesSeq.hasMoreElements()) {
-                                def role = rolesSeq.nextElement()
-                                if (role instanceof ASN1Sequence) {
-                                    def roleObj = role.getObjectAt(0)
-                                    if (roleObj instanceof ASN1ObjectIdentifier) {
-                                        roles.push(roleObj.getId())
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return roles
+        return result;
     }
 }
 
@@ -226,25 +91,7 @@ def certToObject(String certPem) {
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
     Certificate certificate = cf.generateCertificate(certStream);
     def object = [
-      expiryDate: certificate.getNotAfter().toString(),
-      subjectDN: certificate.getSubjectDN(),
-      subjectDNComponents:  CertificateParserHelper.parseDN(certificate.getSubjectDN().toString()),
-      subjectAlternativeNames: CertificateParserHelper.getSubjectAltName(certificate),
-      eku: CertificateParserHelper.getExtendedKeyUsageAsText(certificate),
-      issuerDN: certificate.getIssuerDN(),
-      issuerUniqueID: certificate.getIssuerUniqueID(),
-      issuerAlternativeNames: certificate.getIssuerAlternativeNames(),
-      issuerX500Principal: certificate.getIssuerX500Principal(),
-      subjectUniqueID: certificate.getSubjectUniqueID(),
-      subjectX500Principal: certificate.getSubjectX500Principal(),
-      serialNumber: certificate.getSerialNumber(),
-      sigAlgName: certificate.getSigAlgName(),
-      sigAlgOID: certificate.getSigAlgOID(),
-      signature: certificate.getSignature(),
-      type: certificate.getType(),
-      version: certificate.getVersion(),
-      roles: CertificateParserHelper.getRoles(certificate,logger),
-      publicKey: certificate.getPublicKey(),
+            subjectDNComponents:  CertificateParserHelper.parseDN(certificate.getSubjectDN().toString()),
     ]
     logger.debug(SCRIPT_NAME + "Parsed certificate " + object.toString())
     // Add the X509Certificate object after the logging of the parsed data to prevent the logs being spammed

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -80,9 +80,6 @@ switch (method.toUpperCase()) {
         if (!attributes.clientCertificate) {
             return errorResponseFactory.invalidClientMetadataErrorResponse("No client certificate for registration")
         }
-        if (!attributes.clientCertificate.roles) {
-            return errorResponseFactory.invalidClientMetadataErrorResponse("No roles in client certificate for registration")
-        }
 
         if (registrationRequest.hasExpired()){
             logger.debug(SCRIPT_NAME + "Registration request JWT has expired")


### PR DESCRIPTION
ParseCertificate is only needed by routes: 03-ob-dcr-register-tpp and 72-ob-jwkms-apiclient-getssa. 

Removing ParseCertificate from other routes that previously needed it for checking the roles, as this is now done using ApiClient data.

Removed logic from ParseCertificate that is no longer used, minimal amount of cert data is parsed and added to the attributes context for use by the aforementioned routes that still require it.

https://github.com/SecureApiGateway/SecureApiGateway/issues/859