### PR TITLE
916: Fixing TokenEndpointTransportCertValidationFilter error responses

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/mtls/FromHeaderCertificateRetriever.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/mtls/FromHeaderCertificateRetriever.java
@@ -54,7 +54,7 @@ public class FromHeaderCertificateRetriever implements CertificateRetriever {
         final String headerValue = request.getHeaders().getFirst(certificateHeaderName);
         if (headerValue == null) {
             logger.debug("({}) No client cert could be found for header: {}", fapInteractionId, certificateHeaderName);
-            throw new CertificateException("No client cert could be found for header: " + certificateHeaderName);
+            throw new CertificateException("Client mTLS certificate not provided");
         }
         final String certPem;
         try {

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/mtls/TransportCertValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/mtls/TransportCertValidationFilter.java
@@ -80,8 +80,7 @@ public class TransportCertValidationFilter implements Filter {
         this.transportCertValidator = transportCertValidator;
     }
 
-    // FIXME
-    static Response createErrorResponse(String message) {
+    private Response createErrorResponse(String message) {
         return new Response(Status.BAD_REQUEST).setEntity(json(object(field("error_description", message))));
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/FromHeaderCertificateRetrieverTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/FromHeaderCertificateRetrieverTest.java
@@ -68,7 +68,7 @@ class FromHeaderCertificateRetrieverTest {
         final CertificateException certificateException = assertThrows(CertificateException.class,
                 () -> headerCertificateRetrievesr.retrieveCertificate(new RootContext("test"), requestWithNoHeader));
 
-        assertEquals("No client cert could be found for header: clientCertHeader", certificateException.getMessage());
+        assertEquals("Client mTLS certificate not provided", certificateException.getMessage());
     }
 
     @Test

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/TokenEndpointTransportCertValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/TokenEndpointTransportCertValidationFilterTest.java
@@ -263,10 +263,11 @@ class TokenEndpointTransportCertValidationFilterTest {
         }
 
         private void validateResponseIsBadRequest(Response response, String expectedErrorMsg) {
-            assertEquals(Status.BAD_REQUEST, response.getStatus());
+            assertEquals(Status.UNAUTHORIZED, response.getStatus());
             try {
-                final Object responseJson = response.getEntity().getJson();
-                assertEquals(expectedErrorMsg, json(responseJson).get("error_description").asString());
+                final JsonValue jsonResponse = json(response.getEntity().getJson());
+                assertEquals(expectedErrorMsg, jsonResponse.get("error_description").asString());
+                assertEquals("invalid_client", jsonResponse.get("error").asString());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
When mTLS cert validation is done as part of the token_endpoint AS route, then error responses need to conform to the OAuth 2.0 spec. https://www.rfc-editor.org/rfc/rfc6749#section-5.2

Adding an errorResponse method to TokenEndpointTransportCertValidationFilter which produces errors in the correct format. Example response:
```
HTTP 401 UNAUTHORIZED
{
  "error":"invalid_client",
  "error_description":"Client mTLS certificate not provided"
}
```

The TransportCertValidationFilter is used on Open Banking routes, it needs to produce an error that conforms to the OB spec and and therefore has not been updated.

https://github.com/SecureApiGateway/SecureApiGateway/issues/916