### PR TITLE
917: Configuring server connector in order to fix a HTTP 414 error

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/admin.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/admin.json
@@ -27,5 +27,14 @@
       }
     }
   ],
+  "connectors": [
+    {
+      "port": 8080,
+      "vertx": {
+        "maxInitialLineLength": 8192,
+        "maxHeaderSize": 16384
+      }
+    }
+  ],
   "mode": "DEVELOPMENT"
 }

--- a/config/7.1.0/securebanking/ig/config/prod/config/admin.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/admin.json
@@ -27,5 +27,14 @@
       }
     }
   ],
+  "connectors": [
+    {
+      "port": 8080,
+      "vertx": {
+        "maxInitialLineLength": 8192,
+        "maxHeaderSize": 16384
+      }
+    }
+  ],
   "mode": "PRODUCTION"
 }


### PR DESCRIPTION
The connector configuration in admin.json configures the HTTP Server settings for IG.

Adding this configuration and increasing the maxInitialLineLength from the default 4k to 8k to fix an issue with long request URIs resulting in a HTTP 414 error.

Setting maxHeaderSize to 16k to match the value used in http client configuration in config.json

https://github.com/SecureApiGateway/SecureApiGateway/issues/917