### PR TITLE
883: Configuring ApiClient.name to be equal to a value from the software statement

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -161,7 +161,7 @@ def buildApiClientIdmObject(oauth2ClientId, softwareStatement) {
   def apiClientIdmObj = [
           "_id"           : oauth2ClientId,
           "id"            : softwareStatement.getSoftwareId(),
-          "name"          : softwareStatement.getSoftwareId(),
+          "name"          : softwareStatement.getClientName(),
           "ssa"           : softwareStatement.getB64EncodedJwtString(),
           "roles"         : softwareStatement.getRoles(),
           "oauth2ClientId": oauth2ClientId,

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
@@ -44,6 +44,7 @@ public class SoftwareStatement extends SapiJwt {
     private final URL trustedDirectoryJwksUrl;
     private final String orgId;
     private final String softwareId;
+    private final String clientName;
     private final boolean hasJwksUri;
     private final URL jwksUri;
     private final JWKSet jwksSet;
@@ -59,6 +60,7 @@ public class SoftwareStatement extends SapiJwt {
         super(builder);
         this.orgId = builder.orgId;
         this.softwareId = builder.softwareId;
+        this.clientName = builder.clientName;
         this.hasJwksUri = builder.hasJwksUri;
         this.jwksUri = builder.jwksUri;
         this.jwksSet = builder.jwkSet;
@@ -94,6 +96,13 @@ public class SoftwareStatement extends SapiJwt {
      */
     public String getSoftwareId() {
         return softwareId;
+    }
+
+    /**
+     * @return the name of the
+     */
+    public String getClientName() {
+        return clientName;
     }
 
     /**
@@ -137,6 +146,7 @@ public class SoftwareStatement extends SapiJwt {
         private TrustedDirectory trustedDirectory;
         private String orgId;
         private String softwareId;
+        private String clientName;
         private boolean hasJwksUri;
         private URL jwksUri;
         private JWKSet jwkSet;
@@ -187,6 +197,7 @@ public class SoftwareStatement extends SapiJwt {
             }
             this.orgId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementOrgIdClaimName());
             this.softwareId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementSoftwareIdClaimName());
+            this.clientName = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementClientNameClaimName());
             this.trustedDirectoryJwksUrl = trustedDirectory.getDirectoryJwksUri();
             this.redirectUris = claimsSet.getRequiredUriListClaim(trustedDirectory.getSoftwareStatementRedirectUrisClaimName());
             this.roles = claimsSet.getRequiredStringListClaim(trustedDirectory.getSoftwareStatementRolesClaimName());

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
@@ -99,7 +99,7 @@ public class SoftwareStatement extends SapiJwt {
     }
 
     /**
-     * @return the name of the
+     * @return the name of the software client, this is a human-readable name representing the piece of software that is registered
      */
     public String getClientName() {
         return clientName;

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -94,4 +94,9 @@ public interface TrustedDirectory {
      * @return the name of the claim in the software statement that holds the roles allocated to this software statement
      */
     String getSoftwareStatementRolesClaimName();
+
+    /**
+     * @return the name of the claim in the software statement that holds the name of the software client
+     */
+    String getSoftwareStatementClientNameClaimName();
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -53,7 +53,9 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
 
     final static String softwareStatementRedirectUriClaimName = "software_redirect_uris";
 
-    final static String softwareStatementRolesClaimName = "software_roles";
+    static final String softwareStatementRolesClaimName = "software_roles";
+
+    static final String softwareStatementClientNameClaimName = "software_client_name";
 
     static {
         try {
@@ -106,5 +108,10 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     @Override
     public String getSoftwareStatementRolesClaimName() {
         return softwareStatementRolesClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementClientNameClaimName() {
+        return softwareStatementClientNameClaimName;
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -56,6 +56,8 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
 
     final static String softwareStatementRolesClaimName = "software_roles";
 
+    private static final String softwareStatementSoftwareClientNameClaimName = "software_client_name";
+
     /**
      * Constructor
      * @param secureApiGatewayJwksUri The jwks_uri against which SSAs issued by the Secure API Gateway can be
@@ -108,5 +110,10 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     @Override
     public String getSoftwareStatementRolesClaimName() {
         return softwareStatementRolesClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementClientNameClaimName() {
+        return softwareStatementSoftwareClientNameClaimName;
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementTestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementTestFactory.java
@@ -27,7 +27,8 @@ import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryTestFactory
 
 public class SoftwareStatementTestFactory {
     private static final String ORG_ID = "Acme Inc.";
-    private static final String SOFTWARE_ID ="Acme App";
+    private static final String SOFTWARE_ID ="1234567890";
+    private static final String SOFTWARE_CLIENT_NAME = "Acme App";
     private static final String JWKS_URI = "https://jwks.com";
     private static final JsonValue JWKS_SET;
     private static final List<String> REDIRECT_URIS =
@@ -47,6 +48,7 @@ public class SoftwareStatementTestFactory {
         claims.put(directory.getSoftwareStatementJwksUriClaimName(), JWKS_URI);
         claims.put(directory.getSoftwareStatementRedirectUrisClaimName(), REDIRECT_URIS);
         claims.put(directory.getSoftwareStatementRolesClaimName(), ROLES);
+        claims.put(directory.getSoftwareStatementClientNameClaimName(), SOFTWARE_CLIENT_NAME);
         claims.putAll(overrideSsaClaims);
         return claims;
     };
@@ -61,6 +63,7 @@ public class SoftwareStatementTestFactory {
         claims.put(directory.getSoftwareStatementJwksClaimName(), JWKS_SET.getObject());
         claims.put(directory.getSoftwareStatementRedirectUrisClaimName(), REDIRECT_URIS);
         claims.put(directory.getSoftwareStatementRolesClaimName(), ROLES);
+        claims.put(directory.getSoftwareStatementClientNameClaimName(), SOFTWARE_CLIENT_NAME);
         claims.putAll(overrideSsaClaims);
         return claims;
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
@@ -32,6 +32,7 @@ class TrustedDirectoryOpenBankingTestTest {
         assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);
         assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementOrgIdClaimName);
         assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementSoftwareIdClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementClientNameClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementClientNameClaimName);
     }
 
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -60,6 +60,7 @@ class TrustedDirectoryServiceStaticTest {
         assertThat(directoryConfig.getSoftwareStatementJwksUriClaimName()).isNull();
         assertThat(directoryConfig.getSoftwareStatementOrgIdClaimName()).isEqualTo("org_id");
         assertThat(directoryConfig.getSoftwareStatementSoftwareIdClaimName()).isEqualTo("software_id");
+        assertThat(directoryConfig.getSoftwareStatementClientNameClaimName()).isEqualTo("software_client_name");
     }
 
     @Test

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTestFactory.java
@@ -78,6 +78,11 @@ public class TrustedDirectoryTestFactory {
         public String getSoftwareStatementRolesClaimName() {
             return "software_roles";
         }
+
+        @Override
+        public String getSoftwareStatementClientNameClaimName() {
+            return "software_client_name";
+        }
     };
 
     private static TrustedDirectory jwksBasedTrustedDirectory = new TrustedDirectory() {
@@ -124,6 +129,11 @@ public class TrustedDirectoryTestFactory {
         @Override
         public String getSoftwareStatementRolesClaimName() {
             return "software_roles";
+        }
+
+        @Override
+        public String getSoftwareStatementClientNameClaimName() {
+            return "software_client_name";
         }
     };
 


### PR DESCRIPTION
Adding support for clientName claim in the TrustedDirectory configuration, using this to extract the clientName from the software statement during DCR. Using the value extracted to set the IDM ApiClient.name field.

https://github.com/SecureApiGateway/SecureApiGateway/issues/883