### PR TITLE
812: release action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,12 +22,12 @@ jobs:
         id: get_version
         run: |
           echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
-          echo "MAVEN_SERVER_ID=maven.forgerock.org-community" >> $GITHUB_ENV
+          echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community" >> $GITHUB_ENV
 
       - name: Set up snapshot forgerock maven repository
         if: contains( env.VERSION, 'SNAPSHOT')
         run: |
-          echo "MAVEN_SERVER_ID=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
+          echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
 
       - uses: actions/setup-java@v3
         name: set java and maven cache
@@ -36,17 +36,22 @@ jobs:
           java-version: '17'
           architecture: x64
           cache: 'maven'
-          server-id: ${{ env.MAVEN_SERVER_ID }} # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: MAVEN_SERVER_ID
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
       - name: Build maven
         run: |
-          mvn clean install 
+          mvn clean install
+        env:
+          MAVEN_SERVER_ID: forgerock-private-releases # protected repo id to get the protected dependencies
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
       - name: Deploy artifact package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
         env:
+          MAVEN_SERVER_ID: ${{ env.MAVEN_SERVER_COMMUNITY }} # community repo to publish the java artifact
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,8 +1,11 @@
-name: merge
+name: merge-master
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    paths-ignore:
+      - README.md
 
 env:
   SERVICE_NAME: ig
@@ -15,9 +18,41 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Get version
+        id: get_version
+        run: |
+          echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
+          echo "MAVEN_SERVER_ID=maven.forgerock.org-community" >> $GITHUB_ENV
+
+      - name: Set up snapshot forgerock maven repository
+        if: contains( env.VERSION, 'SNAPSHOT')
+        run: |
+          echo "MAVEN_SERVER_ID=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
+
+      - uses: actions/setup-java@v3
+        name: set java and maven cache
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+          architecture: x64
+          cache: 'maven'
+          server-id: ${{ env.MAVEN_SERVER_ID }} # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
+          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
+
+      - name: Build maven
+        run: |
+          mvn clean install 
+
+      - name: Deploy artifact package
+        run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
+        env:
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+
       - uses: google-github-actions/auth@v0
         with:
-          credentials_json: ${{ secrets.GCR_KEY }}
+          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
@@ -26,33 +61,11 @@ jobs:
       - run: |
           gcloud auth configure-docker
 
-      - name: Setup defaults action java and maven properties
-        uses: actions/setup-java@v1
-        with:
-          java-version: "17"
-          architecture: x64
-          server-id: forgerock-private-releases # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username in deploy
-          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
-
-      - name: Cache Maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
-
-      - name: Build maven
-        run: |
-          mvn clean install
-        env:
-          MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
-
       - name: docker build
         run: |
-          make build-docker-ig tag=${{ env.GIT_SHA_SHORT }} env="prod"
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
+          make docker tag=${{ env.GIT_SHA_SHORT }}
+          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
+          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}
 
       - name: 'run functional tests'
         uses: codefresh-io/codefresh-pipeline-runner@master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,9 @@ jobs:
           java-version: '17'
           architecture: x64
           cache: 'maven'
+          server-id: forgerock-private-releases # protected release repo
+          server-username: FR_ARTIFACTORY_USER # env variable for username to authentication protected repo
+          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable encrypted password to authentication protected repo
 
       - uses: google-github-actions/auth@v0
         with:
@@ -42,6 +45,9 @@ jobs:
       - name: Build maven
         run: |
           mvn clean install
+        env:
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,9 +18,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # set java and cache
+      - uses: actions/setup-java@v3
+        id: set_java_maven
+        name: set java and maven cache
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+          architecture: x64
+          cache: 'maven'
+
       - uses: google-github-actions/auth@v0
         with:
-          credentials_json: ${{ secrets.GCR_KEY }}
+          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
@@ -29,34 +39,16 @@ jobs:
       - run: |
           gcloud auth configure-docker
 
-      - name: Setup defaults action java and maven properties
-        uses: actions/setup-java@v1
-        with:
-          java-version: "17"
-          architecture: x64
-          server-id: forgerock-private-releases # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username in deploy
-          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
-
-      - name: Cache Maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
-
       - name: Build maven
         run: |
           mvn clean install
-        env:
-          MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
 
       - name: Build Docker Image
         run: |
           # Create development mode docker image
-          make build-docker-ig tag=$PR_NUMBER
+          make docker tag=$PR_NUMBER env="dev"
           # Create production mode docker image
-          make build-docker-ig tag="$PR_NUMBER-prod" env="prod"
+          make docker tag="$PR_NUMBER-prod"
 
       - name: Create lowercase Github Username
         id: toLowerCase

--- a/.github/workflows/release-publish-java.yml
+++ b/.github/workflows/release-publish-java.yml
@@ -1,0 +1,62 @@
+name: release-publish-java
+run-name: Java Release '${{ inputs.release_version_number }}'
+on:
+  workflow_call:
+    inputs:
+      release_version_number:
+        required: true
+        type: string
+      release_tag_ref:
+        required: true
+        type: string
+      java_version:
+        required: false
+        type: string
+        default: '17'
+    secrets:
+      FR_ARTIFACTORY_USER:
+        required: true
+      FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
+        required: true
+jobs:
+  build_deploy_java:
+    name: Build and deploy java artifact
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v3
+        id: checkout_tag
+        name: checkout release tag
+        with:
+          ref: ${{ inputs.release_tag_ref }} # tag created by maven release plugin prepare goal
+
+      # set java and cache
+      - uses: actions/setup-java@v3
+        id: set_java_maven
+        name: set java and maven cache
+        with:
+          distribution: 'adopt'
+          java-version: ${{ inputs.java_version }}
+          architecture: x64
+          cache: 'maven'
+          server-id: MAVEN_SERVER_ID
+          server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
+          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
+
+      - name: Build maven
+        run: |
+          mvn clean install
+        env:
+          MAVEN_SERVER_ID: forgerock-private-releases # protected repo id to get the protected dependencies
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+
+      # Deploy the java artifact
+      - name: Deploy release
+        id: deploy
+        run: |
+          mvn clean deploy -Ddockerfile.skip=true
+        env:
+          MAVEN_SERVER_ID: maven.forgerock.org-community
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: create-release
 run-name: Create release '${{ inputs.release_version_number }}'
 # What it does:
 # - Call release-prepare workflow
-# - Call release-publish-java workflow
+# - Call local repository release-publish-java workflow
 # - Call release-publish-docker workflow
 # - Call release-publish-draft-and-pr
 on:
@@ -34,7 +34,7 @@ jobs:
   release_java:
     name: Call publish java
     needs: [ release_prepare ]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-java.yml@master
+    uses: ./.github/workflows/release-publish-java.yml
     with:
       release_version_number: ${{ inputs.release_version_number }}
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,65 @@
-name: Publish package to the ForgeRock artifactory
+name: create-release
+run-name: Create release '${{ inputs.release_version_number }}'
+# What it does:
+# - Call release-prepare workflow
+# - Call release-publish-java workflow
+# - Call release-publish-docker workflow
+# - Call release-publish-draft-and-pr
 on:
-  release:
-    types: [published]
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    name: Deploy release
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Release notes"
+        required: false
+        type: string
+        default: ''
+      release_version_number:
+        description: "Provide release version number"
+        required: true
+        type: string
 
-      - name: Build Docker Image
-        run: |
-          make docker tag=${{ github.event.release.tag_name }} env="prod" gcr-repo=${{ secrets.RELEASE_REPO }}
+jobs:
+
+  release_prepare: # prepare for a release in scm, creates the tag and release branch with the proper release versions
+    name: Call release prepare
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-prepare.yml@master
+    with:
+      release_version_number: ${{ inputs.release_version_number }}
+    secrets:
+      GPG_PRIVATE_KEY_BOT: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
+      GPG_KEY_PASSPHRASE_BOT: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
+      GIT_COMMIT_USERNAME_BOT: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+      GIT_COMMIT_AUTHOR_EMAIL_BOT: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+
+  release_java:
+    name: Call publish java
+    needs: [ release_prepare ]
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-java.yml@master
+    with:
+      release_version_number: ${{ inputs.release_version_number }}
+      release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
+    secrets:
+      FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+      FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+
+  release_docker:
+    name: Call publish docker
+    needs: [ release_prepare, release_java ]
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-docker.yml@master
+    with:
+      release_version_number: ${{ inputs.release_version_number }}
+      release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
+      SERVICE_NAME: securebanking-openbanking-uk-rcs
+    secrets:
+      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
+      GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
+
+  release_draft_and_pr:
+    name: Call publish draft and PR
+    needs: [ release_prepare, release_java, release_docker ]
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-draft-and-pr.yml@master
+    with:
+      release_version_number: ${{ inputs.release_version_number }}
+      release_branch_ref: ${{ needs.release_prepare.outputs.release_branch_ref }}
+      release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
+      release_notes: ${{ inputs.notes }}

--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -14,5 +14,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: success()
         env:
-          SLACK_WEBHOOK: ${{ secrets.WEBHOOK_SBAT_DEV_SLACK }}
+          SLACK_WEBHOOK: ${{ secrets.WEBHOOK_SBAT_NOTIFY_SLACK }}
           SLACK_COLOR: ${{ job.status }}

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,18 @@
-gcr-repo := sbat-gcr-develop
+repo := sbat-gcr-develop
 
-build-docker: conf
+
+docker: conf
 ifndef tag
 	$(warning no tag supplied; latest assumed)
 	$(eval tag=latest)
 endif
-	docker build docker/7.1.0/ig/ -t eu.gcr.io/${gcr-repo}/securebanking/gate/ig:${tag}
-	docker push eu.gcr.io/${gcr-repo}/securebanking/gate/ig:${tag}
-
-build-docker-ig: conf
-ifndef tag
-	$(warning no tag supplied; latest assumed)
-	$(eval tag=latest)
-endif
-	docker build docker/7.1.0/ig/ -t eu.gcr.io/${gcr-repo}/securebanking/gate/ig:${tag}
-	docker push eu.gcr.io/${gcr-repo}/securebanking/gate/ig:${tag}
+	docker build docker/7.1.0/ig/ -t eu.gcr.io/${repo}/securebanking/gate/ig:${tag}
+	docker push eu.gcr.io/${repo}/securebanking/gate/ig:${tag}
 
 conf:
 ifndef env
-	$(warning no env supplied; dev assumed)
-	$(eval env=dev)
+	$(warning no env supplied; prod assumed)
+	$(eval env=prod)
 endif
 	if [ "${env}" = "prod" ]; then \
   		IG_MODE="production"; \

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <!-- https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html -->
         <release.java.version>11</release.java.version>
         <copyright-current-year>2022</copyright-current-year>
-        <uk.bom.version>0.9.0-SNAPSHOT</uk.bom.version>
+        <uk.bom.version>0.9.0</uk.bom.version>
         <openig.version>7.1.0</openig.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
@@ -80,11 +80,10 @@
 
         </dependencies>
     </dependencyManagement>
+
     <scm>
-        <connection>scm:git:git@github.com:SecureApiGateway/secure-api-gateway-ob-uk.git
-        </connection>
-        <developerConnection>scm:git:git@github.com:SecureApiGateway/secure-api-gateway-ob-uk.git
-        </developerConnection>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk.git</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
Changes to make ready build and publish `IG` java extensions and docker image.

> To build the java artifact is necessary a specific maven settings to download the dependencies from the protected repository, so that it is not possible call the reusable workflow `release-publish-java` from gateway-parent.

- Updated make file, now if env is not provided we assumed 'prod' as environment to build the docker image
- Updated merge master workflow
- Updated PR workflow
- Created local `release-publish-java` workflow to setup properly the maven setting to retrieve the dependencies from protected repository.
- Created release workflow, to build the java artifact is necessary use the local `release-publish-java` workflow
   ```yaml
    release_java:
    name: Call publish java
    needs: [ release_prepare ]
    uses: ./.github/workflows/release-publish-java.yml
    ....
    ```
- updated pom file

Issue: https://github.com/secureapigateway/secureapigateway/issues/812