### PR TITLE
945: Add route to return key/pem for signing cert

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/74-ob-jwkms-apiclient-get-tls-cert.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/74-ob-jwkms-apiclient-get-tls-cert.json
@@ -8,7 +8,10 @@
     "type": "ScriptableHandler",
     "config": {
       "type": "application/x-groovy",
-      "file": "JwkmsGetTlsCert.groovy"
+      "file": "JwkmsGetTlsCert.groovy",
+      "args": {
+        "keyType": "tls"
+      }
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-apiclient-get-signing-cert.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/75-ob-jwkms-apiclient-get-signing-cert.json
@@ -1,0 +1,17 @@
+{
+  "comment": "Convert incoming JWK set to PEM encoded Signing client cert and key",
+  "name" : "75 - API Client Onboarding - Extract Signing Cert",
+  "auditService": "AuditService-OB-Route",
+  "condition" : "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/apiclient/getsigcert')}",
+  "handler":     {
+    "name": "JwkmsIssueCert",
+    "type": "ScriptableHandler",
+    "config": {
+      "type": "application/x-groovy",
+      "file": "JwkmsGetTlsCert.groovy",
+      "args": {
+        "keyType": "sig"
+      }
+    }
+  }
+}

--- a/config/7.1.0/securebanking/ig/routes/routes-service/76-ob-jwkms-test-directory-jwks.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/76-ob-jwkms-test-directory-jwks.json
@@ -1,6 +1,6 @@
 {
   "comment": "Hosts the JWK Set for the Test Directory JWT issuer, used when validating signatures of JWTs produced by the Test Directory",
-  "name" : "75 - JWK Set service for Test Directory JWT issuer",
+  "name" : "76 - JWK Set service for Test Directory JWT issuer",
   "auditService": "AuditService-OB-Route",
   "condition" : "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/testdirectory/jwks')}",
   "handler":     {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsGetTlsCert.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/JwkmsGetTlsCert.groovy
@@ -10,16 +10,18 @@ if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
 SCRIPT_NAME = "[JwkmsGetTlsCert] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
-def getTlsKey(jwks) {
+logger.debug("obtaining certs of type " + keyType)
+
+RSAKey getKeyOfType(jwks, keyType) {
     List<RSAKey> jwkKeys = jwks.getKeys();
 
-    def key = null;
+    RSAKey key = null;
 
     jwkKeys.forEach(k -> {
         def use = k.getKeyUse().identifier();
         logger.debug(SCRIPT_NAME + "Key use " + use);
-        if (use == "tls") {
-            logger.debug(SCRIPT_NAME + "Found TLS key " + k);
+        if (use == keyType) {
+            logger.debug(SCRIPT_NAME + "Found " + keyType + " key " + k);
             key = k;
         }
     });
@@ -28,46 +30,50 @@ def getTlsKey(jwks) {
 }
 
 JWKSet jwks = JWKSet.parse(request.entity.getString());
-
 if (!jwks) {
-    logger.error(SCRIPT_NAME + "Couldn't parse request body as JWK set");
-    return new Response(Status.BAD_REQUEST);
+    logger.error(SCRIPT_NAME + "Couldn't parse request body as JWK set")
+    return new Response(Status.BAD_REQUEST)
 }
 
-RSAKey jwk = getTlsKey(jwks);
+if (!keyType) {
+    logger.error(SCRIPT_NAME + "Script must be passed a keyType argument")
+    return new Response(Status.INTERNAL_SERVER_ERROR)
+}
+
+RSAKey jwk = getKeyOfType(jwks, keyType)
 
 if (!jwk) {
-    logger.error(SCRIPT_NAME + "Couldn't find TLS key in JWK set");
-    return new Response(Status.BAD_REQUEST);
+    logger.error(SCRIPT_NAME + "Couldn't find " + keyType + ' key in JWK set')
+    return new Response(Status.BAD_REQUEST)
 }
 
-PrivateKey privateKey = jwk.toPrivateKey();
+PrivateKey privateKey = jwk.toPrivateKey()
 
 if (!privateKey) {
-    logger.error(SCRIPT_NAME + "Couldn't find private key in tls jwk");
-    return new Response(Status.BAD_REQUEST);
+    logger.error(SCRIPT_NAME + "Couldn't find private key in tls jwk")
+    return new Response(Status.BAD_REQUEST)
 }
 
 List<X509Certificate> certChain = jwk.getParsedX509CertChain();
 
 if (!certChain) {
-    logger.error(SCRIPT_NAME + "Couldn't find cert chain in tls jwk");
-    return new Response(Status.BAD_REQUEST);
+    logger.error(SCRIPT_NAME + "Couldn't find cert chain in tls jwk")
+    return new Response(Status.BAD_REQUEST)
 }
 
 def pemify(obj) {
-    StringWriter writer = new StringWriter();
-    JcaPEMWriter pemWriter = new JcaPEMWriter(writer);
-    pemWriter.writeObject(obj);
-    pemWriter.flush();
-    pemWriter.close();
+    StringWriter writer = new StringWriter()
+    JcaPEMWriter pemWriter = new JcaPEMWriter(writer)
+    pemWriter.writeObject(obj)
+    pemWriter.flush()
+    pemWriter.close()
 
-    return writer.toString();
+    return writer.toString()
 }
 
-def certPem = "";
-certChain.forEach(cert -> { certPem = certPem.concat(pemify(cert))});
-def keyPem  = pemify(privateKey);
+def certPem = ""
+certChain.forEach(cert -> { certPem = certPem.concat(pemify(cert))})
+def keyPem  = pemify(privateKey)
 
 Response response = new Response(Status.OK)
 response.getHeaders().add("Content-Type","text/plain");

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -317,8 +317,8 @@ private void validateRegistrationRedirectUris(RegistrationRequest registrationRe
  * <a href="https://openbankinguk.github.io/dcr-docs-pub/v3.3/dynamic-client-registration.html#obclientregistrationrequest1">
  * data dictionary for OBClientRegistrationRequest1 </a>
  * it is stated that:
- * "scope 	1..1 	scope 	Scopes the client is asking for (if not specified, default scopes are assigned by the AS).
- * This consists of a list scopes separated by spaces. 	String(256)"
+ * "scope     1..1     scope     Scopes the client is asking for (if not specified, default scopes are assigned by the AS).
+ * This consists of a list scopes separated by spaces.     String(256)"
  *
  * In the Open Banking issued SSA we can find no scopes defined, however, we do have 'software_roles' which is an array
  * of strings containing AISP, PISP, or a subset thereof, or ASPSP. We must check that the scopes requested are allowed


### PR DESCRIPTION
There is a convenience method to allow clients to obtain the tls key/pem pair from the jwks issued by IG. There needs to be one for the sig key/pem pair too, then clients can easily obtain the key to use for signing

Issue: https://github.com/secureapigateway/secureapigateway/issues/945