### PR TITLE
947: Validation of initiation object, skip patch the debtor account and update accountId when debtor account is null

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RepoConsent.groovy
@@ -47,52 +47,14 @@ def buildPatchRequest(incomingRequest, intentType) {
         ]);
     }
 
-    // Payments Intent: Update Debtor account and accountId
-    if (incomingRequest.data && incomingRequest.data.debtorAccount) {
-        if(incomingRequest.data.debtorAccount.accounts[0]) {
-            if(incomingRequest.data.debtorAccount.accounts[0].schemeName) {
-                body.push([
-
-                        "operation": "add",
-                        "field"    : "OBIntentObject/Data/Initiation/DebtorAccount/SchemeName",
-                        "value"    : incomingRequest.data.debtorAccount.accounts[0].schemeName
-                ])
-            }
-            if(incomingRequest.data.debtorAccount.accounts[0].identification) {
-                body.push([
-
-                        "operation": "add",
-                        "field"    : "OBIntentObject/Data/Initiation/DebtorAccount/Identification",
-                        "value"    : incomingRequest.data.debtorAccount.accounts[0].identification
-                ])
-            }
-            if(incomingRequest.data.debtorAccount.accounts[0].name) {
-                body.push([
-
-                        "operation": "add",
-                        "field"    : "OBIntentObject/Data/Initiation/DebtorAccount/Name",
-                        "value"    : incomingRequest.data.debtorAccount.accounts[0].name
-                ])
-            }
-            if(incomingRequest.data.debtorAccount.accounts[0].secondaryIdentification) {
-                body.push([
-
-                        "operation": "add",
-                        "field"    : "OBIntentObject/Data/Initiation/DebtorAccount/SecondaryIdentification",
-                        "value"    : incomingRequest.data.debtorAccount.accounts[0].secondaryIdentification
-                ])
-            }
-        }
-
-        if(incomingRequest.data.debtorAccount.accountId) {
-            body.push([
-
-                    "operation": "add",
-                    "field"    : "AccountId",
-                    "value"    : incomingRequest.data.debtorAccount.accountId
-            ])
-        }
+    if(incomingRequest.accountId) {
+        body.push([
+                "operation": "add",
+                "field"    : "AccountId",
+                "value"    : incomingRequest.accountId
+        ])
     }
+
     logger.debug(SCRIPT_NAME + "Patch request body:\n" + body + "\n")
 
     return body


### PR DESCRIPTION
Currently to store the account to perform a payment we use the field defined as `debtorAccount`.

Spec validation rule: The PISP must ensure that the Initiation and Risk sections of the international-payment match the corresponding Initiation and Risk sections of the international-payment-consent resource. If the two do not match, the ASPSP must not process the request and must respond with a 400 (Bad Request)

The `debtorAccount` field is patched when the psu submit the consent decision, in consequence when the TPP submit a payment, and the system validates the initiation object from payment request against the initiation object from the consent, the validation fails because the initiation objects do not match because the consent has been modified by the system.

We need to skip update the `debtorAccount` field in the consent and store the account to perform the payment in the `accountId` field outside the `OBIntentObject`.

- The debtor account must still the same provided by the TPP when creates the consent
- Deleted update the debtor account on the consent
- Added logic to set the accountId with the account to perform the payment

Issue: https://github.com/secureapigateway/secureapigateway/issues/947
Comment: https://github.com/secureapigateway/secureapigateway/issues/947#issuecomment-1521744538