### PR TITLE
978: Allow Test Directory to be disabled by removing its configuration properties

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -447,21 +447,6 @@
       }
     },
     {
-      "name":"TestDirectorySigningKeyStore",
-      "type": "KeyStoreSecretStore",
-      "config": {
-        "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
-        "storeType": "PKCS12",
-        "storePassword": "ig.test.directory.signing.keystore.storepass",
-        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
-        "secretsProvider": "SystemAndEnvSecretStore-IAM",
-        "mappings": [{
-          "secretId": "jwt.signer",
-          "aliases": [ "&{ig.test.directory.signing.keystore.alias}" ]
-        }]
-      }
-    },
-    {
       "name": "OBJwkSetService",
       "type": "CaffeineCachingJwkSetService",
       "config": {

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -435,21 +435,6 @@
       }
     },
     {
-      "name":"TestDirectorySigningKeyStore",
-      "type": "KeyStoreSecretStore",
-      "config": {
-        "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
-        "storeType": "PKCS12",
-        "storePassword": "ig.test.directory.signing.keystore.storepass",
-        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
-        "secretsProvider": "SystemAndEnvSecretStore-IAM",
-        "mappings": [{
-          "secretId": "jwt.signer",
-          "aliases": [ "&{ig.test.directory.signing.keystore.alias}" ]
-        }]
-      }
-    },
-    {
       "name": "OBJwkSetService",
       "type": "CaffeineCachingJwkSetService",
       "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -3,6 +3,23 @@
   "name": "72 - API client onboarding - generate test SSA",
   "auditService": "AuditService-OB-Route",
   "condition": "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/apiclient/getssa')}",
+  "heap": [
+    {
+      "name":"TestDirectorySigningKeyStore",
+      "type": "KeyStoreSecretStore",
+      "config": {
+        "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
+        "storeType": "PKCS12",
+        "storePassword": "ig.test.directory.signing.keystore.storepass",
+        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
+        "secretsProvider": "SystemAndEnvSecretStore-IAM",
+        "mappings": [{
+          "secretId": "jwt.signer",
+          "aliases": [ "&{ig.test.directory.signing.keystore.alias}" ]
+        }]
+      }
+    }
+  ],
   "handler": {
     "type": "Chain",
     "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/76-ob-jwkms-test-directory-jwks.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/76-ob-jwkms-test-directory-jwks.json
@@ -3,6 +3,23 @@
   "name" : "76 - JWK Set service for Test Directory JWT issuer",
   "auditService": "AuditService-OB-Route",
   "condition" : "${security.enableTestTrustedDirectory && matches(request.uri.path, '^/jwkms/testdirectory/jwks')}",
+  "heap": [
+    {
+      "name":"TestDirectorySigningKeyStore",
+      "type": "KeyStoreSecretStore",
+      "config": {
+        "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
+        "storeType": "PKCS12",
+        "storePassword": "ig.test.directory.signing.keystore.storepass",
+        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
+        "secretsProvider": "SystemAndEnvSecretStore-IAM",
+        "mappings": [{
+          "secretId": "jwt.signer",
+          "aliases": [ "&{ig.test.directory.signing.keystore.alias}" ]
+        }]
+      }
+    }
+  ],
   "handler":     {
     "name": "JwkSetHandler-TA",
     "type": "JwkSetHandler",


### PR DESCRIPTION
The `TestDirectorySigningKeyStore` object is currently defined in config.json's heap and referenced by the routes that use it. This means that all configuration properties needed to configure this object must be supplied in order for IG to start. 

Therefore, even if we remove the Test Directory routes this [config](https://github.com/SecureApiGateway/SecureApiGateway/wiki/Configuring-Trusted-Directories#configuring-test-trusted-directory) is still needed. The config is complex and shouldn't be required if a deployment never wishes to use the functionality.

In this change we are moving`TestDirectorySigningKeyStore` into the heap of the routes that use it. This means that if we omit the Test Directory configuration properties then only those routes are broken, all other gateway functionality/routes will work.

To disable the Test Directory functionality properly, it is recommended to remove the routes: 7*-ob-jwkms-*.json from the docker image that is going to be deployed.

https://github.com/SecureApiGateway/SecureApiGateway/issues/978