### PR TITLE
Adding crosscheck between request consentId vs token consentId

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -111,6 +111,15 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
           "comment": "Check consent authorised via AM authz policy",
           "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type": "PolicyEnforcementFilter",
@@ -132,7 +141,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}"
+                "${attributes.openbanking_intent_id}"
               ]
             },
             "amService": "AmService-OBIE",
@@ -168,7 +177,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "AISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -111,6 +111,15 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
           "comment": "Check consent authorised via AM authz policy",
           "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type": "PolicyEnforcementFilter",
@@ -132,7 +141,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}"
+                "${attributes.openbanking_intent_id}"
               ]
             },
             "amService": "AmService-OBIE",
@@ -168,7 +177,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "AISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -141,6 +141,15 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
           "comment": "Check payment request against authorised consent, via AM policy engine",
           "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type": "PolicyEnforcementFilter",
@@ -162,7 +171,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${split(request.uri.path, '/')[5]}"
+                "${attributes.openbanking_intent_id}"
               ],
               "request_method": [
                 "${request.method}"
@@ -200,7 +209,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -184,7 +202,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}"
+                "${attributes.openbanking_intent_id}"
               ],
               "initiation": [
                 "${attributes.initiationRequest}"
@@ -212,7 +230,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -184,7 +202,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${toJson(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value}"
+                "${attributes.openbanking_intent_id}"
               ],
               "initiation": [
                 "${attributes.initiationRequest}"
@@ -238,7 +256,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -169,15 +187,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "EncodeInitiation.groovy"
-          }
-        },
-        {
-          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
-          "name": "SaveIntentIdOnAttributesContext",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "SaveIntentIdOnAttributesContext.groovy"
           }
         },
         {
@@ -256,7 +265,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -160,15 +178,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "EncodeInitiation.groovy"
-          }
-        },
-        {
-          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
-          "name": "SaveIntentIdOnAttributesContext",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "SaveIntentIdOnAttributesContext.groovy"
           }
         },
         {
@@ -247,7 +256,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -141,6 +141,15 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
           "comment": "Check payment request against authorised consent, via AM policy engine",
           "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type": "PolicyEnforcementFilter",
@@ -162,7 +171,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${split(request.uri.path, '/')[5]}"
+                "${attributes.openbanking_intent_id}"
               ],
               "request_method": [
                 "${request.method}"
@@ -200,7 +209,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -160,15 +178,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "EncodeInitiation.groovy"
-          }
-        },
-        {
-          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
-          "name": "SaveIntentIdOnAttributesContext",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "SaveIntentIdOnAttributesContext.groovy"
           }
         },
         {
@@ -247,7 +256,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -141,6 +141,15 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
           "comment": "Check payment request against authorised consent, via AM policy engine",
           "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type": "PolicyEnforcementFilter",
@@ -162,7 +171,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${split(request.uri.path, '/')[5]}"
+                "${attributes.openbanking_intent_id}"
               ],
               "request_method": [
                 "${request.method}"
@@ -200,7 +209,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -169,15 +187,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "EncodeInitiation.groovy"
-          }
-        },
-        {
-          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
-          "name": "SaveIntentIdOnAttributesContext",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "SaveIntentIdOnAttributesContext.groovy"
           }
         },
         {
@@ -256,7 +265,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -120,6 +120,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -160,15 +178,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "EncodeInitiation.groovy"
-          }
-        },
-        {
-          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
-          "name": "SaveIntentIdOnAttributesContext",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "SaveIntentIdOnAttributesContext.groovy"
           }
         },
         {
@@ -247,7 +256,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -141,6 +141,15 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
           "comment": "Check payment request against authorised consent, via AM policy engine",
           "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
           "type": "PolicyEnforcementFilter",
@@ -162,7 +171,7 @@
                 "${attributes.tppId}"
               ],
               "intent_id": [
-                "${split(request.uri.path, '/')[5]}"
+                "${attributes.openbanking_intent_id}"
               ],
               "request_method": [
                 "${request.method}"
@@ -200,7 +209,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -107,6 +107,24 @@
           }
         },
         {
+          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
+          "name": "SaveIntentIdOnAttributesContext",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "SaveIntentIdOnAttributesContext.groovy"
+          }
+        },
+        {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Check incoming detached signature and save to route state. If the detached signature is for an unencoded payload, validation performed as well",
           "name": "ProcessDetachedSig",
           "type": "ScriptableFilter",
@@ -147,15 +165,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "EncodeInitiation.groovy"
-          }
-        },
-        {
-          "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
-          "name": "SaveIntentIdOnAttributesContext",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "SaveIntentIdOnAttributesContext.groovy"
           }
         },
         {
@@ -234,7 +243,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "new groovy.json.JsonSlurper().parseText(contexts.oauth2.accessToken.info.claims).id_token.openbanking_intent_id.value",
+              "consentIdLocator": "${attributes.openbanking_intent_id}",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
@@ -1,6 +1,5 @@
 import org.forgerock.http.protocol.*
 import com.forgerock.sapi.gateway.rest.HttpHeaderNames
-import groovy.json.JsonSlurper
 
 /**
  * This script is comparing the consentId from the request payload versus the consentId from the provided access token.

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
@@ -16,7 +16,7 @@ logger.debug(SCRIPT_NAME + 'Running...')
 def accessTokenIntentId = attributes.openbanking_intent_id
 
 if (!accessTokenIntentId) {
-    throw new IllegalStateException("openbanking_intent_id claim is missing from the access token");
+    throw new IllegalStateException("openbanking_intent_id claim is missing from the attributes context");
 }
 
 // Get the intent Id from the request body

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
@@ -15,19 +15,23 @@ logger.debug(SCRIPT_NAME + 'Running...')
 // Get the intent id from the access token
 def accessTokenIntentId = attributes.openbanking_intent_id
 
+if (!accessTokenIntentId) {
+    throw new IllegalStateException("openbanking_intent_id claim is missing from the access token");
+}
+
 // Get the intent Id from the request body
 def requestIntentId = request.entity.getJson().Data.ConsentId
 
 logger.debug(SCRIPT_NAME + 'Comparing token intent id {} with request intent id {}', accessTokenIntentId, requestIntentId)
 
 // Compare the id's and only allow the filter chain to proceed if they exists and they match
-if (accessTokenIntentId && requestIntentId && accessTokenIntentId == requestIntentId) {
+if (requestIntentId && accessTokenIntentId == requestIntentId) {
     // Request is valid, allow it to pass
     return next.handle(context, request)
 } else {
     Response response = new Response(Status.UNAUTHORIZED)
-    String message = 'invalid_request'
-    logger.error(SCRIPT_NAME + message + ' consentIds are not matching')
+    String message = 'consentId from the request does not match the openbanking_intent_id claim from the access token'
+    logger.error(SCRIPT_NAME + message)
     response.headers['Content-Type'] = 'application/json'
     response.entity = "{ \"error\":\"" + message + "\"}"
     return response

--- a/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ConsentIdValidator.groovy
@@ -1,0 +1,34 @@
+import org.forgerock.http.protocol.*
+import com.forgerock.sapi.gateway.rest.HttpHeaderNames
+import groovy.json.JsonSlurper
+
+/**
+ * This script is comparing the consentId from the request payload versus the consentId from the provided access token.
+ * By doing this comparison, we prevent resources being submitted with a token obtained for another consent.
+ */
+
+String fapiInteractionId = request.getHeaders().getFirst(HttpHeaderNames.X_FAPI_INTERACTION_ID);
+if (fapiInteractionId == null) { fapiInteractionId = 'No ' + HttpHeaderNames.X_FAPI_INTERACTION_ID + ' header'}
+SCRIPT_NAME = '[ConsentIdValidator] (' + fapiInteractionId + ') - '
+logger.debug(SCRIPT_NAME + 'Running...')
+
+// Get the intent id from the access token
+def accessTokenIntentId = attributes.openbanking_intent_id
+
+// Get the intent Id from the request body
+def requestIntentId = request.entity.getJson().Data.ConsentId
+
+logger.debug(SCRIPT_NAME + 'Comparing token intent id {} with request intent id {}', accessTokenIntentId, requestIntentId)
+
+// Compare the id's and only allow the filter chain to proceed if they exists and they match
+if (accessTokenIntentId && requestIntentId && accessTokenIntentId == requestIntentId) {
+    // Request is valid, allow it to pass
+    return next.handle(context, request)
+} else {
+    Response response = new Response(Status.UNAUTHORIZED)
+    String message = 'invalid_request'
+    logger.error(SCRIPT_NAME + message + ' consentIds are not matching')
+    response.headers['Content-Type'] = 'application/json'
+    response.entity = "{ \"error\":\"" + message + "\"}"
+    return response
+}

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
@@ -14,7 +14,12 @@ def intentId = JsonValue.json(Json.readJson(contexts.oauth2.accessToken.info.cla
 logger.info(SCRIPT_NAME + "Intent Id value: " + intentId)
 
 if (!intentId) {
-    throw new IllegalStateException("openbanking_intent_id claim could not be extracted from the access token");
+    Response response = new Response(Status.BAD_REQUEST)
+    response.headers['Content-Type'] = "application/json"
+    String message = 'Cannot parse openbanking_intent_id claim from the provided access token'
+    logger.error(SCRIPT_NAME + message)
+    response.entity = "{ \"error\":\"" + message + "\"}"
+    return response
 }
 
 attributes.put('openbanking_intent_id', intentId)

--- a/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/SaveIntentIdOnAttributesContext.groovy
@@ -12,6 +12,11 @@ logger.debug(SCRIPT_NAME + "Running...")
 
 def intentId = JsonValue.json(Json.readJson(contexts.oauth2.accessToken.info.claims)).get("id_token").get("openbanking_intent_id").get("value").asString()
 logger.info(SCRIPT_NAME + "Intent Id value: " + intentId)
+
+if (!intentId) {
+    throw new IllegalStateException("openbanking_intent_id claim could not be extracted from the access token");
+}
+
 attributes.put('openbanking_intent_id', intentId)
 
 next.handle(context, request)


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/979

Added a new validation script on the payment submit routes.
This script is comparing the consentId from the request payload versus the consentId from the provided access token. By doing this comparison, we prevent resources being submitted with a token obtained for another consent.