### PR TITLE
578: Retain Path field in OB Errors object

### DIFF
--- a/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/ObResponseCheck.groovy
@@ -67,6 +67,14 @@ Map<String, String> getGenericError(Status status, String responseBody) {
     if(responseObj.Code){
       errorCode = responseObj.Errors[0].ErrorCode
       message = responseObj.Errors[0].Message
+      path = responseObj.Errors[0].Path
+      if (path) {
+        return [
+                ErrorCode: errorCode,
+                Message: message,
+                Path: path
+        ]
+      }
     }
     if (responseObj.error) {
       message += " [" + responseObj.error + "]"


### PR DESCRIPTION
For validation errors, the RS will return Error objects which include a path field. The path indicates which field within the request is invalid.

Adding logic to retain this field if it is present in the RS response.

There's a separate issue to review and rewrite the ObResponseCheck script, see: https://github.com/SecureApiGateway/SecureApiGateway/issues/872



https://github.com/SecureApiGateway/SecureApiGateway/issues/578