### PR TITLE
1012: Domestic Payment Consent route to call RS

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -159,7 +159,8 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
               "x-api-client-id": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -162,7 +162,7 @@
               "X-Forwarded-Prefix"
             ],
             "add": {
-              "x-ob-client-id": [
+              "x-api-client-id": [
                 "${contexts.oauth2.accessToken.info.aud}"
               ],
               "X-Forwarded-Host": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -127,77 +127,12 @@
           }
         },
         {
-          "comment": "Fetch Open Banking consent from IDM to get the resource owner id",
-          "name": "GetResourceOwnerIdFromConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GetResourceOwnerIdFromConsent.groovy",
-            "clientHandler": "IDMClientHandler",
-            "args": {
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgObjUser": "&{user.object}"
-            }
-          }
-        },
-        {
           "comment": "Gets the intent id from the access token claims and saves it on the attributes context",
           "name": "SaveIntentIdOnAttributesContext",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
             "file": "SaveIntentIdOnAttributesContext.groovy"
-          }
-        },
-        {
-          "comment": "Check payment request against authorised consent, via AM policy engine",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${attributes.resourceOwnerUsername}",
-              "intent_type": "pisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${attributes.openbanking_intent_id}"
-              ],
-              "request_method": [
-                "${request.method}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Adjust URL for downstream resource server",
-          "name": "TranslateDomesticPaymentFundsConfirmationResource",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "TranslatePaymentFundsConfirmationResource.groovy",
-            "args": {
-              "routeArgAmountQueryParameter": "amount",
-              "routeArgVersionQueryParameter": "version"
-            }
           }
         },
         {
@@ -227,6 +162,9 @@
               "X-Forwarded-Prefix"
             ],
             "add": {
+              "x-ob-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -156,7 +156,7 @@
           "config": {
             "messageType": "REQUEST",
             "add": {
-              "x-ob-client-id": [
+              "x-api-client-id": [
                 "${contexts.oauth2.accessToken.info.sub}"
               ],
               "X-Forwarded-Host": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -155,6 +155,12 @@
           "type": "HeaderFilter",
           "config": {
             "messageType": "REQUEST",
+            "remove": [
+              "host",
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
+            ],
             "add": {
               "x-api-client-id": [
                 "${contexts.oauth2.accessToken.info.sub}"
@@ -165,12 +171,7 @@
               "X-Forwarded-Prefix": [
                 "/rs"
               ]
-            },
-            "remove": [
-              "host",
-              "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
-            ]
+            }
           }
         }
       ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -1,7 +1,7 @@
 {
   "name": "31 - Open Banking RS Payment Consent",
   "auditService": "AuditService-OB-Route",
-  "baseURI": "https://&{identity.platform.fqdn}",
+  "baseURI": "${urls.rsBaseUri}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/pisp/domestic-payment-consents((?!funds-confirmation).)*$')}",
   "handler": {
     "type": "Chain",
@@ -114,66 +114,6 @@
           }
         },
         {
-          "comment": "Check incoming idempotency key header",
-          "name": "ValidateIdempotencyKey",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "clientHandler": "IDMClientHandler",
-            "file": "CheckIdempotencyKey.groovy",
-            "args": {
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "idempotencyArgFieldToFilter": "IdempotencyKey",
-              "idempotencyArgExpirationFieldToFilter": "IdempotencyKeyExpirationTime",
-              "intentArgObject": "domesticPaymentIntent"
-            }
-          }
-        },
-        {
-          "comment": "Validate debtor account in RS",
-          "other": "ValidateDebtorAccountInRS",
-          "name": "ValidateDebtorAccountInRS",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ValidateDebtorAccountInRS.groovy",
-            "clientHandler": "ForgeRockClientHandler",
-            "args": {
-              "routeArgRsBaseURI": "${urls.rsBaseUri}"
-            }
-          }
-        },
-        {
-          "comment": "Calculate response elements in RS",
-          "name": "CalculateResponseElementsInRS",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "CalculateResponseElementsInRS.groovy",
-            "clientHandler": "ForgeRockClientHandler",
-            "args": {
-              "routeArgRsBaseURI": "${urls.rsBaseUri}",
-              "routeArgIntentQueryParameter": "intent",
-              "routeArgIntentType": "PDC_"
-            }
-          }
-        },
-        {
-          "comment": "Prepare request for IDM",
-          "name": "ProcessPaymentConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ProcessPaymentConsent.groovy",
-            "args": {
-              "routeArgObjIntent": "domesticPaymentIntent",
-              "routeArgObIntentObjectType": "OBWriteDomesticConsentResponse5",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgConsentIdPrefix": "PDC_"
-            }
-          }
-        },
-        {
           "comment": "Prepare audit trail for consent",
           "type": "ScriptableFilter",
           "config": {
@@ -189,28 +129,48 @@
           }
         },
         {
-          "comment": "Add host header for downstream services",
-          "name": "HeaderFilter-ChangeHostToIDM",
-          "type": "HeaderFilter",
+          "comment": "Adjust URL for downstream resource server",
+          "type": "UriPathRewriteFilter",
           "config": {
-            "messageType": "REQUEST",
-            "remove": [
-              "host"
-            ]
+            "mappings": {
+              "/rs": "/"
+            },
+            "failureHandler": {
+              "type": "StaticResponseHandler",
+              "config": {
+                "status": 500,
+                "headers": {
+                  "Content-Type": [
+                    "text/plain"
+                  ]
+                },
+                "entity": "Invalid URL produced"
+              }
+            }
           }
         },
         {
-          "comment": "Add access token to IDM request",
-          "type": "ClientCredentialsOAuth2ClientFilter",
+          "comment": "Add headers required by RS",
+          "name": "HeaderFilter-RS",
+          "type": "HeaderFilter",
           "config": {
-            "clientId": "&{ig.client.id}",
-            "clientSecretId": "ig.client.secret",
-            "secretsProvider": "SystemAndEnvSecretStore-IAM",
-            "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
-            "scopes": [
-              "fr:idm:*"
-            ],
-            "handler": "TokenRequestHandler"
+            "messageType": "REQUEST",
+            "add": {
+              "x-ob-client-id": [
+                "${contexts.oauth2.accessToken.info.sub}"
+              ],
+              "X-Forwarded-Host": [
+                "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
+              ]
+            },
+            "remove": [
+              "host",
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix"
+            ]
           }
         }
       ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -207,7 +207,7 @@
               "X-Forwarded-Prefix"
             ],
             "add": {
-              "x-ob-client-id": [
+              "x-api-client-id": [
                 "${contexts.oauth2.accessToken.info.aud}"
               ],
               "X-Forwarded-Host": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -181,47 +181,6 @@
           }
         },
         {
-          "comment": "Check payment request against authorised consent, via AM policy engineß",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${contexts.oauth2.accessToken.info.sub}",
-              "intent_type": "pisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${attributes.openbanking_intent_id}"
-              ],
-              "initiation": [
-                "${attributes.initiationRequest}"
-              ],
-              "request_method": [
-                "${request.method}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {
@@ -248,6 +207,9 @@
               "X-Forwarded-Prefix"
             ],
             "add": {
+              "x-ob-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -204,7 +204,8 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
               "x-api-client-id": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -154,7 +154,7 @@
               "X-Forwarded-Prefix"
             ],
             "add": {
-              "x-ob-client-id": [
+              "x-api-client-id": [
                 "${contexts.oauth2.accessToken.info.aud}"
               ],
               "X-Forwarded-Host": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -128,58 +128,6 @@
           }
         },
         {
-          "comment": "Fetch Open Banking consent from IDM to get the resource owner id",
-          "name": "GetResourceOwnerIdFromConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GetResourceOwnerIdFromConsent.groovy",
-            "clientHandler": "IDMClientHandler",
-            "args": {
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgObjUser": "&{user.object}"
-            }
-          }
-        },
-        {
-          "comment": "Check payment request against authorised consent, via AM policy engine",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${attributes.resourceOwnerUsername}",
-              "intent_type": "pisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${split(request.uri.path, '/')[5]}"
-              ],
-              "request_method": [
-                "${request.method}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {
@@ -206,6 +154,9 @@
               "X-Forwarded-Prefix"
             ],
             "add": {
+              "x-ob-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -151,7 +151,8 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
               "x-api-client-id": [


### PR DESCRIPTION
Updating Domestic Payment Consent route to reverse proxy RS.

Removing filters which impl IDM Consent logic in IG from Domestic Payment routes.

Removing AM policy script call from Domestic Payment routes, this is now implemented in the RS/RCS.

Adding `x-api-client-id` header to all Domestic Payment API calls.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1012