### PR TITLE
1020: Fix docker build deleting apt-get commands

### DIFF
--- a/docker/7.1.0/ig/Dockerfile
+++ b/docker/7.1.0/ig/Dockerfile
@@ -1,11 +1,5 @@
 FROM gcr.io/forgerock-io/ig:7.1.0
 
-# Base image is using the forgerock user, switch to root for priviledged tasks
-USER root
-RUN sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list
-RUN apt-get update && apt-get install nano
-RUN apt update && apt install vim -y
-
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
- Deleted apt-get commands from docker file to update the system and install nano and vim to avoid the bug [993755](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=993755) reported in debian

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1020