### PR TITLE
1035: Updating Accounts Access routes to support Mongo Consent Store

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -2,7 +2,7 @@
   "comment": "Open Banking Account Access Consents",
   "name": "10 - Open Banking Account Access Consent",
   "auditService": "AuditService-OB-Route",
-  "baseURI": "https://&{identity.platform.fqdn}",
+  "baseURI": "${urls.rsBaseUri}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/aisp/account-access-consents')}",
   "handler": {
     "type": "Chain",
@@ -91,20 +91,6 @@
           }
         },
         {
-          "commment": "Prepare account consent for IDM - change request URL and add CREST action",
-          "name": "ProcessAccountConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ProcessAccountConsent.groovy",
-            "args": {
-              "routeArgObjAccountAccessConsent": "accountAccessIntent",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgConsentIdPrefix": "AAC_"
-            }
-          }
-        },
-        {
           "comment": "Prepare audit trail for consent",
           "type": "ScriptableFilter",
           "config": {
@@ -120,14 +106,49 @@
           }
         },
         {
+          "comment": "Adjust URL for downstream resource server",
+          "type": "UriPathRewriteFilter",
+          "config": {
+            "mappings": {
+              "/rs": "/"
+            },
+            "failureHandler": {
+              "type": "StaticResponseHandler",
+              "config": {
+                "status": 500,
+                "headers": {
+                  "Content-Type": [
+                    "text/plain"
+                  ]
+                },
+                "entity": "Invalid URL produced"
+              }
+            }
+          }
+        },
+        {
           "comment": "Add Host header for downstream IDM",
-          "name": "HeaderFilter-ChangeHostToIDM",
+          "name": "HeaderFilter-RS",
           "type": "HeaderFilter",
           "config": {
             "messageType": "REQUEST",
             "remove": [
-              "host"
-            ]
+              "host",
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
+            ],
+            "add": {
+              "x-api-client-id": [
+                "${contexts.oauth2.accessToken.info.sub}"
+              ],
+              "X-Forwarded-Host": [
+                "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
+              ]
+            }
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -144,7 +144,8 @@
               "host",
               "X-Forwarded-Host",
               "X-Forwarded-Prefix",
-              "x-api-client-id"
+              "x-api-client-id",
+              "x-intent-id"
             ],
             "add": {
               "x-api-client-id": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -120,56 +120,7 @@
           }
         },
         {
-          "comment": "Check consent authorised via AM authz policy",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${contexts.oauth2.accessToken.info.sub}",
-              "intent_type": "aisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${attributes.openbanking_intent_id}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check permissions and accounts in authz response from AM",
-          "name": "TranslateAccountsResource",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "TranslateAccountsResource.groovy",
-            "args": {
-              "routeArgUserResourceOwnerHeader": "x-ob-user-id",
-              "routeArgAccountIdsHeader": "x-ob-account-ids",
-              "routeArgPermissionsHeader": "x-ob-permissions"
-            }
-          }
-        },
-        {
-          "comment": "Prepare consent audit trailß",
+          "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -192,9 +143,13 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
+              "x-api-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -155,6 +155,9 @@
               ],
               "X-Forwarded-Prefix": [
                 "/rs"
+              ],
+              "x-intent-id": [
+                "${attributes.openbanking_intent_id}"
               ]
             }
           }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -144,7 +144,8 @@
               "host",
               "X-Forwarded-Host",
               "X-Forwarded-Prefix",
-              "x-api-client-id"
+              "x-api-client-id",
+              "x-intent-id"
             ],
             "add": {
               "x-api-client-id": [

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -120,56 +120,7 @@
           }
         },
         {
-          "comment": "Check consent authorised via AM authz policy",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${contexts.oauth2.accessToken.info.sub}",
-              "intent_type": "aisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${attributes.openbanking_intent_id}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check permissions and accounts in authz response from AM",
-          "name": "TranslateAccountsResource",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "TranslateAccountsResource.groovy",
-            "args": {
-              "routeArgUserResourceOwnerHeader": "x-ob-user-id",
-              "routeArgAccountIdsHeader": "x-ob-account-ids",
-              "routeArgPermissionsHeader": "x-ob-permissions"
-            }
-          }
-        },
-        {
-          "comment": "Prepare consent audit trailß",
+          "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
@@ -192,9 +143,13 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
+              "x-api-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -155,6 +155,9 @@
               ],
               "X-Forwarded-Prefix": [
                 "/rs"
+              ],
+              "x-intent-id": [
+                "${attributes.openbanking_intent_id}"
               ]
             }
           }


### PR DESCRIPTION
- 10-ob-account-consent.json now reverse proxies the RS which implements the Account Access Consents API
- Routes using the consent to access data now no longer call the policy in AM, instead the RS/RCS will enforce this
  - These routes also supply a new header `x-intent-id` which communicates the `openbanking_intent_id` from the access_token
- All routes now supply the `x-api-client-id` header

https://github.com/SecureApiGateway/SecureApiGateway/issues/1035