### PR TITLE
1066: Consolidating ReverseProxyHandlers which call FR products

### DIFF
--- a/config/7.1.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/dev/config/config.json
@@ -172,19 +172,8 @@
       }
     },
     {
-      "name": "SBATReverseProxyHandlerIdentityPlatform",
-      "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM)",
-      "type": "Chain",
-      "config": {
-        "filters" : [ 
-          "TransactionIdOutboundFilter"
-       ],
-        "handler" : "ReverseProxyHandler"
-      }
-    },
-    {
-      "name": "SBATReverseProxyHandlerIdentityPlatformNoCapture",
-      "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM), with the capture decorator disabled",
+      "name": "FRReverseProxyHandlerNoCapture",
+      "comment": "ReverseProxyHandler for calls to the FR services, with the capture decorator disabled",
       "type": "Chain",
       "config": {
         "filters" : [
@@ -194,46 +183,14 @@
       }
     },
     {
-      "name": "SBATReverseProxyHandlerRs",
-      "comment": "ReverseProxyHandler for calls to the SBAT RS",
+      "name": "FRReverseProxyHandler",
+      "comment": "ReverseProxyHandler for calls to the FR services",
       "type": "Chain",
       "config": {
         "filters": [
-          {
-            "comment": "Add x-ob-url header (used by RS)",
-            "name": "HeaderFilter-Add-x-ob-url",
-            "type": "HeaderFilter",
-            "config": {
-              "messageType": "REQUEST",
-              "remove": ["x-ob-url"],
-              "add": {
-                "x-ob-url": [
-                  "https://&{mtls.fqdn}${contexts.router.remainingUri}"
-                ]
-              }
-            }
-          },
           "TransactionIdOutboundFilter"
         ],
         "handler": "ReverseProxyHandler"
-      }
-    },
-
-    {
-      "name": "RcsReverseProxyHandler",
-      "comment": "ReverseProxyHandler for calls to the RCS",
-      "type": "Chain",
-      "config": {
-        "filters": [
-          "TransactionIdOutboundFilter"
-        ],
-        "handler": {
-          "name": "RcsReverseProxyHandlerInner",
-          "type": "ReverseProxyHandler",
-          "config": {
-            "vertx": "${vertxConfig}"
-          }
-        }
       }
     },
     {
@@ -432,6 +389,7 @@
     },
     {
       "name": "OBReverseProxyHandler",
+      "comment": "ReverseProxyHandler for calls to OB Directory services",
       "type": "ReverseProxyHandler",
       "capture": [
         "request",

--- a/config/7.1.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.1.0/securebanking/ig/config/prod/config/config.json
@@ -160,19 +160,8 @@
       }
     },
     {
-      "name": "SBATReverseProxyHandlerIdentityPlatform",
-      "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM)",
-      "type": "Chain",
-      "config": {
-        "filters" : [
-          "TransactionIdOutboundFilter"
-       ],
-        "handler" : "ReverseProxyHandler"
-      }
-    },
-    {
-      "name": "SBATReverseProxyHandlerIdentityPlatformNoCapture",
-      "comment": "ReverseProxyHandler for calls to Identity Platform services (AM or IDM), with the capture decorator disabled",
+      "name": "FRReverseProxyHandlerNoCapture",
+      "comment": "ReverseProxyHandler for calls to the FR services, with the capture decorator disabled",
       "type": "Chain",
       "config": {
         "filters" : [
@@ -182,46 +171,14 @@
       }
     },
     {
-      "name": "SBATReverseProxyHandlerRs",
-      "comment": "ReverseProxyHandler for calls to the SBAT RS",
+      "name": "FRReverseProxyHandler",
+      "comment": "ReverseProxyHandler for calls to the FR services",
       "type": "Chain",
       "config": {
         "filters": [
-          {
-            "comment": "Add x-ob-url header (used by RS)",
-            "name": "HeaderFilter-Add-x-ob-url",
-            "type": "HeaderFilter",
-            "config": {
-              "messageType": "REQUEST",
-              "remove": ["x-ob-url"],
-              "add": {
-                "x-ob-url": [
-                  "https://&{mtls.fqdn}${contexts.router.remainingUri}"
-                ]
-              }
-            }
-          },
           "TransactionIdOutboundFilter"
         ],
         "handler": "ReverseProxyHandler"
-      }
-    },
-
-    {
-      "name": "RcsReverseProxyHandler",
-      "comment": "ReverseProxyHandler for calls to the RCS",
-      "type": "Chain",
-      "config": {
-        "filters": [
-          "TransactionIdOutboundFilter"
-        ],
-        "handler": {
-          "name": "RcsReverseProxyHandlerInner",
-          "type": "ReverseProxyHandler",
-          "config": {
-            "vertx": "${vertxConfig}"
-          }
-        }
       }
     },
     {
@@ -420,6 +377,7 @@
     },
     {
       "name": "OBReverseProxyHandler",
+      "comment": "ReverseProxyHandler for calls to OB Directory services",
       "type": "ReverseProxyHandler",
       "capture": [
         "request",

--- a/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -62,7 +62,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -37,7 +37,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 } 

--- a/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -142,7 +142,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -38,7 +38,7 @@
           }
         }        
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -166,7 +166,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -164,7 +164,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -164,7 +164,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -176,7 +176,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -176,7 +176,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -176,7 +176,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -176,7 +176,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -63,7 +63,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -175,7 +175,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -160,7 +160,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -221,7 +221,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -184,7 +184,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatform"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -176,7 +176,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -199,7 +199,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -168,7 +168,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerRs"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -76,7 +76,7 @@
           }
         }
       ],
-      "handler": "RcsReverseProxyHandler"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
@@ -56,7 +56,7 @@
           }
         }
       ],
-      "handler": "RcsReverseProxyHandler"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/83-rcs-api.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/83-rcs-api.json
@@ -64,7 +64,7 @@
           }
         }
       ],
-      "handler": "RcsReverseProxyHandler"
+      "handler": "FRReverseProxyHandler"
     }
   }
 }

--- a/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/99-ob-as.json
@@ -27,7 +27,7 @@
           }
         }
       ],
-      "handler": "SBATReverseProxyHandlerIdentityPlatformNoCapture"
+      "handler": "FRReverseProxyHandlerNoCapture"
     }
   }
 }


### PR DESCRIPTION
We no longer need specific ReverseProxyHandlers for the RS, as the `x-ob-url` header is no longer required by any APIs (previously required by AISP). Once this is removed the handlers for FR products look identical.

Consolidating the handlers to: FRReverseProxyHandler and FRReverseProxyHandlerNoCapture

The OBReverseProxyHandler remains unchanged, and should be used when calling out to the OB Directory.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1066