### PR TITLE
1064: Updating International Standing Order routes to work with RS Consent API

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -1,7 +1,7 @@
 {
   "name": "55 - Open Banking RS International Standing Order Consent",
   "auditService": "AuditService-OB-Route",
-  "baseURI": "https://&{identity.platform.fqdn}",
+  "baseURI": "${urls.rsBaseUri}",
   "condition": "${matches(request.uri.path, '^/rs/open-banking/v(\\\\d+.)?(\\\\d+.)?(\\\\*|\\\\d+)/pisp/international-standing-order-consents((?!funds-confirmation).)*$')}",
   "handler": {
     "type": "Chain",
@@ -114,75 +114,6 @@
           }
         },
         {
-          "comment": "Check incoming idempotency key header",
-          "name": "ValidateIdempotencyKey",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "clientHandler": "IDMClientHandler",
-            "file": "CheckIdempotencyKey.groovy",
-            "args": {
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "idempotencyArgFieldToFilter": "IdempotencyKey",
-              "idempotencyArgExpirationFieldToFilter": "IdempotencyKeyExpirationTime",
-              "intentArgObject": "internationalStandingOrdersIntent"
-            }
-          }
-        },
-        {
-          "comment": "Validate debtor account in RS",
-          "other": "ValidateDebtorAccountInRS",
-          "name": "ValidateDebtorAccountInRS",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ValidateDebtorAccountInRS.groovy",
-            "clientHandler": "ForgeRockClientHandler",
-            "args": {
-              "routeArgRsBaseURI": "${urls.rsBaseUri}"
-            }
-          }
-        },
-        {
-          "comment": "Calculate response elements in RS",
-          "name": "CalculateResponseElementsInRS",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "CalculateResponseElementsInRS.groovy",
-            "clientHandler": "ForgeRockClientHandler",
-            "args": {
-              "routeArgRsBaseURI": "${urls.rsBaseUri}",
-              "routeArgIntentQueryParameter": "intent",
-              "routeArgIntentType": "PISOC_"
-            }
-          }
-        },
-        {
-          "comment": "Check Frequency parameter in standing order payload",
-          "name": "CheckFrequencyValue",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "CheckFrequencyValue.groovy"
-          }
-        },
-        {
-          "comment": "Prepare request for IDM",
-          "name": "ProcessPaymentConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "ProcessPaymentConsent.groovy",
-            "args": {
-              "routeArgObjIntent": "internationalStandingOrdersIntent",
-              "routeArgObIntentObjectType": "OBWriteInternationalStandingOrderConsentResponse7",
-              "routeArgObjApiClient": "apiClient",
-              "routeArgConsentIdPrefix": "PISOC_"
-            }
-          }
-        },
-        {
           "comment": "Prepare audit trail for consent",
           "type": "ScriptableFilter",
           "config": {
@@ -198,28 +129,49 @@
           }
         },
         {
-          "comment": "Add host header for downstream services",
-          "name": "HeaderFilter-ChangeHostToIDM",
+          "comment": "Adjust URL for downstream resource server",
+          "type": "UriPathRewriteFilter",
+          "config": {
+            "mappings": {
+              "/rs": "/"
+            },
+            "failureHandler": {
+              "type": "StaticResponseHandler",
+              "config": {
+                "status": 500,
+                "headers": {
+                  "Content-Type": [
+                    "text/plain"
+                  ]
+                },
+                "entity": "Invalid URL produced"
+              }
+            }
+          }
+        },
+        {
+          "comment": "Add headers required by RS",
+          "name": "HeaderFilter-RS",
           "type": "HeaderFilter",
           "config": {
             "messageType": "REQUEST",
             "remove": [
-              "host"
-            ]
-          }
-        },
-        {
-          "comment": "Add access token to IDM request",
-          "type": "ClientCredentialsOAuth2ClientFilter",
-          "config": {
-            "clientId": "&{ig.client.id}",
-            "clientSecretId": "ig.client.secret",
-            "secretsProvider": "SystemAndEnvSecretStore-IAM",
-            "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
-            "scopes": [
-              "fr:idm:*"
+              "host",
+              "X-Forwarded-Host",
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
-            "handler": "TokenRequestHandler"
+            "add": {
+              "x-api-client-id": [
+                "${contexts.oauth2.accessToken.info.sub}"
+              ],
+              "X-Forwarded-Host": [
+                "&{mtls.fqdn}"
+              ],
+              "X-Forwarded-Prefix": [
+                "/rs"
+              ]
+            }
           }
         }
       ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -151,15 +151,6 @@
           }
         },
         {
-          "comment": "Check Frequency parameter in standing order payload",
-          "name": "CheckFrequencyValue",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "CheckFrequencyValue.groovy"
-          }
-        },
-        {
           "comment": "Adjust URL for downstream resource server",
           "type": "UriPathRewriteFilter",
           "config": {
@@ -190,73 +181,6 @@
           }
         },
         {
-          "comment": "Check payment request against authorised consent, via AM policy engineß",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${contexts.oauth2.accessToken.info.sub}",
-              "intent_type": "pisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${attributes.openbanking_intent_id}"
-              ],
-              "initiation": [
-                "${attributes.initiationRequest}"
-              ],
-              "request_method": [
-                "${request.method}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Fetch Open Banking consent from IDM to get the resource owner id",
-          "name": "GetResourceOwnerIdFromConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GetResourceOwnerIdFromConsent.groovy",
-            "clientHandler": "IDMClientHandler",
-            "args": {
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgObjUser": "&{user.object}"
-            }
-          }
-        },
-        {
-          "comment": "Adjust URL for downstream resource server",
-          "name": "TranslatePaymentResource",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "TranslatePaymentResource.groovy",
-            "args": {
-              "routeArgAccountIdHeader": "x-ob-account-id"
-            }
-          }
-        },
-        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {
@@ -280,9 +204,13 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
+              "x-api-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -128,58 +128,6 @@
           }
         },
         {
-          "comment": "Fetch Open Banking consent from IDM to get the resource owner id",
-          "name": "GetResourceOwnerIdFromConsent",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GetResourceOwnerIdFromConsent.groovy",
-            "clientHandler": "IDMClientHandler",
-            "args": {
-              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
-              "routeArgObjUser": "&{user.object}"
-            }
-          }
-        },
-        {
-          "comment": "Check payment request against authorised consent, via AM policy engine",
-          "name": "PolicyEnforcementFilter-OBIE Assets Authorization Filter",
-          "type": "PolicyEnforcementFilter",
-          "config": {
-            "pepRealm": "/&{am.realm}",
-            "application": "Open Banking",
-            "claimsSubject": {
-              "sub": "${attributes.resourceOwnerUsername}",
-              "intent_type": "pisp"
-            },
-            "environment": {
-              "sub": [
-                "${contexts.oauth2.accessToken.info.sub}"
-              ],
-              "tpp_client_id": [
-                "${contexts.oauth2.accessToken.info.aud}"
-              ],
-              "tpp_cert_id": [
-                "${attributes.tppId}"
-              ],
-              "intent_id": [
-                "${split(request.uri.path, '/')[5]}"
-              ],
-              "request_method": [
-                "${request.method}"
-              ]
-            },
-            "amService": "AmService-OBIE",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnPolicyValidationError.groovy"
-              }
-            }
-          }
-        },
-        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {
@@ -203,9 +151,13 @@
             "remove": [
               "host",
               "X-Forwarded-Host",
-              "X-Forwarded-Prefix"
+              "X-Forwarded-Prefix",
+              "x-api-client-id"
             ],
             "add": {
+              "x-api-client-id": [
+                "${contexts.oauth2.accessToken.info.aud}"
+              ],
               "X-Forwarded-Host": [
                 "&{mtls.fqdn}"
               ],


### PR DESCRIPTION
Consent routes now reverse proxy the RS

Removing filters which impl IDM consent logic from routes.

Removing AM policy script call from routes, this is now implemented in the RS.

Adding x-api-client-id header to all routes.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1064