### PR TITLE
1052: Validating Funds Confirmation Request ConsentId is valid for the access_token

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -136,6 +136,18 @@
           }
         },
         {
+          "comment": "Check the consentId in the uri path matches the access_token",
+          "name": "RequestPathConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "RequestPathConsentIdValidator.groovy",
+            "args": {
+              "routeArgConsentIdPathElementIndex": 4
+            }
+          }
+        },
+        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -136,6 +136,18 @@
           }
         },
         {
+          "comment": "Check the consentId in the uri path matches the access_token",
+          "name": "RequestPathConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "RequestPathConsentIdValidator.groovy",
+            "args": {
+              "routeArgConsentIdPathElementIndex": 4
+            }
+          }
+        },
+        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -136,6 +136,18 @@
           }
         },
         {
+          "comment": "Check the consentId in the uri path matches the access_token",
+          "name": "RequestPathConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "RequestPathConsentIdValidator.groovy",
+            "args": {
+              "routeArgConsentIdPathElementIndex": 4
+            }
+          }
+        },
+        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -136,6 +136,15 @@
           }
         },
         {
+          "comment": "Check the consent submitted to match the consent from the access token",
+          "name": "ConsentIdValidator",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ConsentIdValidator.groovy"
+          }
+        },
+        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -137,11 +137,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -117,11 +117,11 @@
         },
         {
           "comment": "Check the consent submitted to match the consent from the access token",
-          "name": "ConsentIdValidator",
+          "name": "RequestEntityConsentIdValidator",
           "type": "ScriptableFilter",
           "config": {
             "type": "application/x-groovy",
-            "file": "ConsentIdValidator.groovy"
+            "file": "RequestEntityConsentIdValidator.groovy"
           }
         },
         {

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RequestEntityConsentIdValidator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RequestEntityConsentIdValidator.groovy
@@ -8,7 +8,7 @@ import com.forgerock.sapi.gateway.rest.HttpHeaderNames
 
 String fapiInteractionId = request.getHeaders().getFirst(HttpHeaderNames.X_FAPI_INTERACTION_ID);
 if (fapiInteractionId == null) { fapiInteractionId = 'No ' + HttpHeaderNames.X_FAPI_INTERACTION_ID + ' header'}
-SCRIPT_NAME = '[ConsentIdValidator] (' + fapiInteractionId + ') - '
+SCRIPT_NAME = '[RequestEntityRequestEntityConsentIdValidator] (' + fapiInteractionId + ') - '
 logger.debug(SCRIPT_NAME + 'Running...')
 
 // Get the intent id from the access token

--- a/config/7.1.0/securebanking/ig/scripts/groovy/RequestPathConsentIdValidator.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/RequestPathConsentIdValidator.groovy
@@ -1,0 +1,37 @@
+import org.forgerock.http.protocol.*
+import com.forgerock.sapi.gateway.rest.HttpHeaderNames
+
+/**
+ * This script is comparing the consentId from the request uri path versus the consentId from the provided access token.
+ * By doing this comparison, we prevent resources being submitted with a token obtained for another consent.
+ */
+
+String fapiInteractionId = request.getHeaders().getFirst(HttpHeaderNames.X_FAPI_INTERACTION_ID);
+if (fapiInteractionId == null) { fapiInteractionId = 'No ' + HttpHeaderNames.X_FAPI_INTERACTION_ID + ' header'}
+SCRIPT_NAME = '[RequestPathConsentIdValidator] (' + fapiInteractionId + ') - '
+logger.debug(SCRIPT_NAME + 'Running...')
+
+// Get the intent id from the access token
+def accessTokenIntentId = attributes.openbanking_intent_id
+
+if (!accessTokenIntentId) {
+    throw new IllegalStateException("openbanking_intent_id claim is missing from the attributes context");
+}
+
+// Get the intent Id from the uri
+def requestIntentId = request.uri.pathElements[routeArgConsentIdPathElementIndex]
+
+logger.debug(SCRIPT_NAME + 'Comparing token intent id {} with request intent id {}', accessTokenIntentId, requestIntentId)
+
+// Compare the id's and only allow the filter chain to proceed if they exists and they match
+if (requestIntentId && accessTokenIntentId == requestIntentId) {
+    // Request is valid, allow it to pass
+    return next.handle(context, request)
+} else {
+    Response response = new Response(Status.UNAUTHORIZED)
+    String message = 'consentId from the request does not match the openbanking_intent_id claim from the access token'
+    logger.error(SCRIPT_NAME + message)
+    response.headers['Content-Type'] = 'application/json'
+    response.entity = "{ \"error\":\"" + message + "\"}"
+    return response
+}


### PR DESCRIPTION
RequestEntityRequestEntityConsentIdValidator (previously called: ConsentIdValidator) ensures that VRP funds confirmation POST request entities have a consentId matching the consentId in the access_token.

New RequestPathConsentIdValidator added for non-VRP payment routes to apply the same validation logic to the consentId in the request URI.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1052