### PR TITLE
1108: Fixing consentIdLocator AuditConsent config

### DIFF
--- a/config/7.2.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -99,7 +99,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "AISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -128,7 +128,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "AISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -128,7 +128,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "AISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -156,7 +156,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -123,7 +123,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -156,7 +156,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -156,7 +156,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -122,7 +122,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "PISP",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -153,7 +153,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -167,7 +167,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "PISP",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -91,7 +91,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "response.entity.getJson().OBIntentObject.Data.ConsentId",
+              "consentIdLocator": "response.entity.getJson().Data.ConsentId",
               "role": "CBPII",
               "event": "CREATE"
             }

--- a/config/7.2.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
@@ -137,7 +137,7 @@
             "args": {
               "auditService": "${heap['AuditService-OB-Consent']}",
               "clock": "${heap['Clock']}",
-              "consentIdLocator": "${attributes.openbanking_intent_id}",
+              "consentIdLocator": "contexts.attributes.openbanking_intent_id",
               "role": "CBPII",
               "event": "EXEC"
             }

--- a/config/7.2.0/securebanking/ig/scripts/groovy/AuditConsent.groovy
+++ b/config/7.2.0/securebanking/ig/scripts/groovy/AuditConsent.groovy
@@ -31,6 +31,11 @@ next.handle(context, request).thenOnResult(response -> {
         logger.info(SCRIPT_NAME + "Error response, skipping audit")
         return
     }
+    // NO_CONTENT is typically returned by deletes, these are currently not supported as the consentIdLocator will fail
+    if (response.status == Status.NO_CONTENT) {
+        logger.info(SCRIPT_NAME + "No Content response, skipping audit")
+        return
+    }
 
     logger.info(SCRIPT_NAME + context)
 

--- a/config/7.2.0/securebanking/ig/scripts/groovy/AuditConsent.groovy
+++ b/config/7.2.0/securebanking/ig/scripts/groovy/AuditConsent.groovy
@@ -1,5 +1,6 @@
 import static org.forgerock.json.resource.Requests.newCreateRequest;
 import static org.forgerock.json.resource.ResourcePath.resourcePath;
+import static com.forgerock.sapi.gateway.rest.HttpHeaderNames.X_FAPI_INTERACTION_ID
 
 SCRIPT_NAME = "[AuditConsent] - "
 
@@ -46,9 +47,9 @@ next.handle(context, request).thenOnResult(response -> {
     JsonValue auditEvent = auditEvent('OB-CONSENT-' + event).add('consent', consent)
 
     def fapiInfo = [:]
-    def values = request.headers.get('x-fapi-interaction-id')
+    def values = request.headers.get(X_FAPI_INTERACTION_ID)
     if (values) {
-        fapiInfo.put( header, values.firstValue)
+        fapiInfo.put(X_FAPI_INTERACTION_ID, values.firstValue)
     }
 
     auditEvent = auditEvent.add('fapiInfo', fapiInfo);


### PR DESCRIPTION
consentIdLocator has been updated to locate the ConsentId in the OB API response, rather than the IDM Consent Store response

Fixing issue when Consent is deleted, the consentIdLocator does not work for this use case currently.

Example audit log:
```
{
    "_id": "cf748620-f908-496b-ad90-396d5eecba48-345",
    "timestamp": 1692269591646,
    "eventName": "OB-CONSENT-CREATE",
    "transactionId": "b485cfdd-d83b-46c2-b4be-0d0fb84ca79c",
    "consent": {
        "id": "AAC_79aa744b-8fec-47a2-8e45-41a7cbf49534",
        "role": "AISP"
    },
    "fapiInfo": {
        "x-fapi-interaction-id": "b485cfdd-d83b-46c2-b4be-0d0fb84ca79c"
    },
    "source": "audit",
    "topic": "ObConsentTopic",
    "level": "INFO"
}
```

https://github.com/SecureApiGateway/SecureApiGateway/issues/1108