### PR TITLE
1120: Switching to use the ForgeRockClientHandler in the DCR AddIgAccessTokenForNewRegistrations filter

### DIFF
--- a/config/7.2.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -133,9 +133,9 @@
                 "secretsProvider": "SystemAndEnvSecretStore-IAM",
                 "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
                 "scopes": [
-                  "dynamic_client_registration fr:idm:*"
+                  "dynamic_client_registration"
                 ],
-                "handler": "TokenRequestHandler"
+                "handler": "ForgeRockClientHandler"
               }
             }
           }


### PR DESCRIPTION
Previously the TokenRequestHandler was being used, this uses the SettingNewEntity filter to change the client_credentials grant into a password grant and adds the username and password. This adds extra processing to the request chain, and is swapping the use of a stronger grant type for a weaker one with no added benefit. 

It is also quite confusing, as in the IG route it appears that we are going to get a client_credentials grant as we are using `ClientCredentialsOAuth2ClientFilter`

Password grant is being removed in OAuth2.1, therefore it should be avoided whenever possible.

Removing unnecessary scope: fr:idm:* from the gateway access_token request

https://github.com/SecureApiGateway/SecureApiGateway/issues/1120