### PR TITLE
1121: Making use of TokenRequestHandler only in IDMClientHandler

### DIFF
--- a/config/7.2.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.2.0/securebanking/ig/config/dev/config/config.json
@@ -224,19 +224,6 @@
       }
     },
     {
-      "name": "TokenRequestHandler",
-      "type": "ScriptableHandler",
-      "config": {
-        "type": "application/x-groovy",
-        "args": {
-          "userId": "&{ig.idm.user}",
-          "password": "&{ig.idm.password}"
-        },
-        "file": "SettingNewEntity.groovy",
-        "clientHandler": "ForgeRockClientHandler"
-      }
-    },
-    {
       "name": "SecretsProvider-AmJWK",
       "type": "SecretsProvider",
       "config": {
@@ -289,7 +276,19 @@
               "scopes": [
                 "fr:idm:*"
               ],
-              "handler": "TokenRequestHandler"
+              "handler": {
+                "name": "TokenRequestHandler",
+                "type": "ScriptableHandler",
+                "config": {
+                  "type": "application/x-groovy",
+                  "args": {
+                    "userId": "&{ig.idm.user}",
+                    "password": "&{ig.idm.password}"
+                  },
+                  "file": "SetIdmPasswordGrantCredentials.groovy",
+                  "clientHandler": "ForgeRockClientHandler"
+                }
+              }
             }
           }
         ],

--- a/config/7.2.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.2.0/securebanking/ig/config/prod/config/config.json
@@ -212,19 +212,6 @@
       }
     },
     {
-      "name": "TokenRequestHandler",
-      "type": "ScriptableHandler",
-      "config": {
-        "type": "application/x-groovy",
-        "args": {
-          "userId": "&{ig.idm.user}",
-          "password": "&{ig.idm.password}"
-        },
-        "file": "SettingNewEntity.groovy",
-        "clientHandler": "ForgeRockClientHandler"
-      }
-    },
-    {
       "name": "SecretsProvider-AmJWK",
       "type": "SecretsProvider",
       "config": {
@@ -277,7 +264,19 @@
               "scopes": [
                 "fr:idm:*"
               ],
-              "handler": "TokenRequestHandler"
+              "handler": {
+                "name": "TokenRequestHandler",
+                "type": "ScriptableHandler",
+                "config": {
+                  "type": "application/x-groovy",
+                  "args": {
+                    "userId": "&{ig.idm.user}",
+                    "password": "&{ig.idm.password}"
+                  },
+                  "file": "SetIdmPasswordGrantCredentials.groovy",
+                  "clientHandler": "ForgeRockClientHandler"
+                }
+              }
             }
           }
         ],

--- a/config/7.2.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -150,20 +150,6 @@
               ]
             }
           }
-        },
-        {
-          "comment": "Obtain access token from authz server and add request's Authorization header",
-          "type": "ClientCredentialsOAuth2ClientFilter",
-          "config": {
-            "clientId": "&{ig.client.id}",
-            "clientSecretId": "ig.client.secret",
-            "secretsProvider": "SystemAndEnvSecretStore-IAM",
-            "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
-            "scopes": [
-              "fr:idm:*"
-            ],
-            "handler": "TokenRequestHandler"
-          }
         }
       ],
       "handler": "FRReverseProxyHandler"

--- a/config/7.2.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.2.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -37,7 +37,7 @@
             "scopes": [
               "trusted_gateway"
             ],
-            "handler": "TokenRequestHandler"
+            "handler": "ForgeRockClientHandler"
           }
         },
         {

--- a/config/7.2.0/securebanking/ig/scripts/groovy/SetIdmPasswordGrantCredentials.groovy
+++ b/config/7.2.0/securebanking/ig/scripts/groovy/SetIdmPasswordGrantCredentials.groovy
@@ -1,7 +1,11 @@
-
+/**
+ * Script to replace client_credentials request string with password grant type and adding the credentials.
+ *
+ * This script is required when requesting an access_token to access IDM.
+ */
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
 if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
-SCRIPT_NAME = "[SettingNewEntity] (" + fapiInteractionId + ") - ";
+SCRIPT_NAME = "[SetIdmPasswordGrantCredentials] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 
 def newEntity = request.getEntity().getString().replace('grant_type=client_credentials','grant_type=password&username=' + userId + '&password=' + java.net.URLEncoder.encode(password, 'UTF-8'))


### PR DESCRIPTION
TokenRequestHandler is only needed by the IDMClientHandler. Moving it as an inline handler definition so that it cannot be used elsewhere. IDM does not appear to support client_credentials access_tokens OOTB, hence why we use the password grant with a special IG IDM user identity.

Renaming SettingNewEntity => SetIdmPasswordGrantCredentials to make it clearer what the script does.

Changing the gateway token request from the token endpoint route to use the ForgeRockClientHandler, as it can use client_credentials flow.

Removing the gateway token request from the OB Account Access route as it is not needed. Only the client's access_token is needed, which the route is validating.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1121