### PR TITLE
1138: Fixing ReSignIdTokenFilter newSigningHandler Promise to use `then` callback instead of `thenAysnc`

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/am/ReSignIdTokenFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/am/ReSignIdTokenFilter.java
@@ -156,14 +156,14 @@ public class ReSignIdTokenFilter implements Filter {
                             return newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
                         }
 
-                        return signingManager.newSigningHandler(signingKeyPurpose).thenAsync(signingHandler -> {
+                        return signingManager.newSigningHandler(signingKeyPurpose).then(signingHandler -> {
                             final String resignedIdTokenJwtString = reSignJwt(signedJwt, signingHandler);
                             logger.debug("id_token re-signed: {}", resignedIdTokenJwtString);
                             idTokenAccessor.setIdToken(resignedIdTokenJwtString);
-                            return newResultPromise(response);
+                            return response;
                         }, nsse -> {
                             logger.error("Failed to create signingHandler", nsse);
-                            return newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
+                            return new Response(Status.INTERNAL_SERVER_ERROR);
                         });
                     });
                 }, e -> {


### PR DESCRIPTION
The callback `newSigningHandler` is used to produce the signed JWT, we are currently using `thenAsync` but this is unnecessary as the callback code does not need to make any subsequent async calls.

Fixing to use the `then` callback as it is simpler and more performant

https://github.com/SecureApiGateway/SecureApiGateway/issues/1138