### PR TITLE
862: Adding certificate validity date check to FAPIAdvancedDCRValidaionFilter

### DIFF
--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/DefaultTransportCertValidatorTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/DefaultTransportCertValidatorTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.mtls;
 
+import static com.forgerock.sapi.gateway.util.CryptoUtils.generateExpiredX509Cert;
 import static com.forgerock.sapi.gateway.util.CryptoUtils.generateRsaKeyPair;
 import static com.forgerock.sapi.gateway.util.CryptoUtils.generateX509Cert;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,13 +88,7 @@ class DefaultTransportCertValidatorTest {
 
     @Test
     void failsWhenCertIsExpired() {
-        final Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.DAY_OF_YEAR, -5);
-        final Date certStartDate = calendar.getTime();
-        calendar.add(Calendar.DAY_OF_YEAR, 1);
-        final Date certEndDate = calendar.getTime();
-
-        final X509Certificate expiredCert = generateX509Cert(generateRsaKeyPair(), "CN=abc", certStartDate, certEndDate);
+        final X509Certificate expiredCert = generateExpiredX509Cert(generateRsaKeyPair(), "CN=abc");
         final CertificateException certificateException = Assertions.assertThrows(CertificateException.class,
                 () -> new DefaultTransportCertValidator("blah").validate(expiredCert, TEST_JWKS));
         assertThat(certificateException.getMessage()).contains("certificate expired on");

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/util/CryptoUtils.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/util/CryptoUtils.java
@@ -139,6 +139,16 @@ public class CryptoUtils {
         }
     }
 
+    public static X509Certificate generateExpiredX509Cert(KeyPair keyPair, String subjectDN) {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_YEAR, -5);
+        final Date certStartDate = calendar.getTime();
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        final Date certEndDate = calendar.getTime();
+
+        return generateX509Cert(keyPair, subjectDN, certStartDate, certEndDate);
+    }
+
     /**
      * Convert an X509Certificate to a PEM string representation
      */


### PR DESCRIPTION
Calling X509Certificate.checkValidity() in FAPIAdvancedDCRValidaionFilter to check if the current date and time are within the validity period for the client's mTLS cert.

https://github.com/SecureApiGateway/SecureApiGateway/issues/862