### PR TITLE
1163: Updating to use ClientCredentialsOAuth2ClientFilter endpointHandler configuration

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -269,24 +269,37 @@
           {
             "type": "ClientCredentialsOAuth2ClientFilter",
             "config": {
-              "clientId": "&{ig.client.id}",
-              "clientSecretId": "ig.client.secret",
-              "secretsProvider": "SystemAndEnvSecretStore-IAM",
               "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
               "scopes": [
                 "fr:idm:*"
               ],
-              "handler": {
-                "name": "TokenRequestHandler",
-                "type": "ScriptableHandler",
+              "endpointHandler": {
+                "name": "ClientCredentialsOAuth2ClientFilterHandler",
+                "type": "Chain",
                 "config": {
-                  "type": "application/x-groovy",
-                  "args": {
-                    "userId": "&{ig.idm.user}",
-                    "password": "&{ig.idm.password}"
+                  "handler": {
+                    "name": "TokenRequestHandler",
+                    "type": "ScriptableHandler",
+                    "config": {
+                      "type": "application/x-groovy",
+                      "args": {
+                        "userId": "&{ig.idm.user}",
+                        "password": "&{ig.idm.password}"
+                      },
+                      "file": "SetIdmPasswordGrantCredentials.groovy",
+                      "clientHandler": "ForgeRockClientHandler"
+                    }
                   },
-                  "file": "SetIdmPasswordGrantCredentials.groovy",
-                  "clientHandler": "ForgeRockClientHandler"
+                  "filters": [
+                    {
+                      "type": "ClientSecretBasicAuthenticationFilter",
+                      "config": {
+                        "clientId": "&{ig.client.id}",
+                        "clientSecretId": "ig.client.secret",
+                        "secretsProvider": "SystemAndEnvSecretStore-IAM"
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -257,24 +257,37 @@
           {
             "type": "ClientCredentialsOAuth2ClientFilter",
             "config": {
-              "clientId": "&{ig.client.id}",
-              "clientSecretId": "ig.client.secret",
-              "secretsProvider": "SystemAndEnvSecretStore-IAM",
               "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
               "scopes": [
                 "fr:idm:*"
               ],
-              "handler": {
-                "name": "TokenRequestHandler",
-                "type": "ScriptableHandler",
+              "endpointHandler": {
+                "name": "ClientCredentialsOAuth2ClientFilterHandler",
+                "type": "Chain",
                 "config": {
-                  "type": "application/x-groovy",
-                  "args": {
-                    "userId": "&{ig.idm.user}",
-                    "password": "&{ig.idm.password}"
+                  "handler": {
+                    "name": "TokenRequestHandler",
+                    "type": "ScriptableHandler",
+                    "config": {
+                      "type": "application/x-groovy",
+                      "args": {
+                        "userId": "&{ig.idm.user}",
+                        "password": "&{ig.idm.password}"
+                      },
+                      "file": "SetIdmPasswordGrantCredentials.groovy",
+                      "clientHandler": "ForgeRockClientHandler"
+                    }
                   },
-                  "file": "SetIdmPasswordGrantCredentials.groovy",
-                  "clientHandler": "ForgeRockClientHandler"
+                  "filters": [
+                    {
+                      "type": "ClientSecretBasicAuthenticationFilter",
+                      "config": {
+                        "clientId": "&{ig.client.id}",
+                        "clientSecretId": "ig.client.secret",
+                        "secretsProvider": "SystemAndEnvSecretStore-IAM"
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -124,14 +124,27 @@
               "comment": "Fetch access token for dynamic client registration - IG credentials to talk to AM",
               "type": "ClientCredentialsOAuth2ClientFilter",
               "config": {
-                "clientId": "&{ig.client.id}",
-                "clientSecretId": "ig.client.secret",
-                "secretsProvider": "SystemAndEnvSecretStore-IAM",
                 "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
                 "scopes": [
                   "dynamic_client_registration"
                 ],
-                "handler": "ForgeRockClientHandler"
+                "endpointHandler": {
+                  "name": "ClientCredentialsOAuth2ClientFilterHandler",
+                  "type": "Chain",
+                  "config": {
+                    "handler": "ForgeRockClientHandler",
+                    "filters": [
+                      {
+                        "type": "ClientSecretBasicAuthenticationFilter",
+                        "config": {
+                          "clientId": "&{ig.client.id}",
+                          "clientSecretId": "ig.client.secret",
+                          "secretsProvider": "SystemAndEnvSecretStore-IAM"
+                        }
+                      }
+                    ]
+                  }
+                }
               }
             }
           }

--- a/config/7.3.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -30,14 +30,27 @@
           "comment": "Add gateway access token to request (custom AT modification script checks access token to enforce route via IG)",
           "type": "ClientCredentialsOAuth2ClientFilter",
           "config": {
-            "clientId": "&{ig.client.id}",
-            "clientSecretId": "ig.client.secret",
-            "secretsProvider": "SystemAndEnvSecretStore-IAM",
             "tokenEndpoint": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/access_token",
             "scopes": [
               "trusted_gateway"
             ],
-            "handler": "ForgeRockClientHandler"
+            "endpointHandler": {
+              "name": "ClientCredentialsOAuth2ClientFilterHandler",
+              "type": "Chain",
+              "config": {
+                "handler": "ForgeRockClientHandler",
+                "filters": [
+                  {
+                    "type": "ClientSecretBasicAuthenticationFilter",
+                    "config": {
+                      "clientId": "&{ig.client.id}",
+                      "clientSecretId": "ig.client.secret",
+                      "secretsProvider": "SystemAndEnvSecretStore-IAM"
+                    }
+                  }
+                ]
+              }
+            }
           }
         },
         {


### PR DESCRIPTION
ClientCredentialsOAuth2ClientFilter configuration is using deprecated options, our configuration has been updated to use the endpointHandler as per the documentation: https://backstage.forgerock.com/docs/ig/2023.4/reference/Filters.html#ClientCredentialsOAuth2ClientFilter

https://github.com/SecureApiGateway/SecureApiGateway/issues/1163