### PR TITLE
1151: Capturing Route Metrics

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/logback.xml
+++ b/config/7.3.0/securebanking/ig/config/dev/config/logback.xml
@@ -25,34 +25,15 @@
             </layout>
         </encoder>
     </appender>
-     
-    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
-        <discriminator>
-            <key>routeId</key>
-            <defaultValue>system</defaultValue>
-        </discriminator>
-        <sift>
-            <!-- Create a separate log file for each <key> -->
-            <appender name="FILE-${routeId}" class="ch.qos.logback.core.rolling.RollingFileAppender">
-                <file>${openig.base}/logs/route-${routeId}.log</file>
-                 
-                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                    <!-- Rotate files daily -->
-                    <fileNamePattern>${openig.base}/logs/route-${routeId}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-                     
-                    <!-- each file should be at most 100MB, keep 30 days worth of history, but at most 3GB -->
-                    <maxFileSize>100MB</maxFileSize>
-                    <maxHistory>30</maxHistory>
-                    <totalSizeCap>3GB</totalSizeCap>
-                </rollingPolicy>
-                 
-                <encoder>
-                    <pattern>%d{HH:mm:ss:SSS} | %-5level | %thread | %logger{20} | %message%n%xException</pattern>
-                </encoder>
-            </appender>
-        </sift>
+    <appender name="METRICS" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
     </appender>
-     
+
+    <logger name="com.forgerock.sapi.gateway.metrics.LoggerRouteMetricsEventPublisher" additivity="false">
+        <appender-ref ref="METRICS" />
+    </logger>
     <root level="FINE">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/config/7.3.0/securebanking/ig/config/prod/config/logback.xml
+++ b/config/7.3.0/securebanking/ig/config/prod/config/logback.xml
@@ -25,34 +25,15 @@
             </layout>
         </encoder>
     </appender>
-     
-    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
-        <discriminator>
-            <key>routeId</key>
-            <defaultValue>system</defaultValue>
-        </discriminator>
-        <sift>
-            <!-- Create a separate log file for each <key> -->
-            <appender name="FILE-${routeId}" class="ch.qos.logback.core.rolling.RollingFileAppender">
-                <file>${openig.base}/logs/route-${routeId}.log</file>
-                 
-                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                    <!-- Rotate files daily -->
-                    <fileNamePattern>${openig.base}/logs/route-${routeId}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-                     
-                    <!-- each file should be at most 100MB, keep 30 days worth of history, but at most 3GB -->
-                    <maxFileSize>100MB</maxFileSize>
-                    <maxHistory>30</maxHistory>
-                    <totalSizeCap>3GB</totalSizeCap>
-                </rollingPolicy>
-                 
-                <encoder>
-                    <pattern>%d{HH:mm:ss:SSS} | %-5level | %thread | %logger{20} | %message%n%xException</pattern>
-                </encoder>
-            </appender>
-        </sift>
+    <appender name="METRICS" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
     </appender>
-     
+
+    <logger name="com.forgerock.sapi.gateway.metrics.LoggerRouteMetricsEventPublisher" additivity="false">
+        <appender-ref ref="METRICS" />
+    </logger>
     <root level="FINE">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -8,6 +8,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Enforce response content type as application/json",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -8,6 +8,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add host to downstream request",
@@ -35,6 +39,15 @@
           "config": {
             "type": "application/x-groovy",
             "file": "FapiCompliantAuthorizeRequestFilter.groovy"
+          }
+        },
+        {
+          "name": "AuthoriseResponseFetchApiClientFilter",
+          "type": "AuthoriseResponseFetchApiClientFilter",
+          "comment": "Add ApiClient data to the context attributes",
+          "config": {
+            "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
+            "clientHandler": "IDMClientHandler"
           }
         },
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
@@ -8,6 +8,16 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter",
+          "config": {
+            "metricsContextSupplier": {
+              "name": "TokenEndpointMetricsContextSupplier",
+              "type": "TokenEndpointMetricsContextSupplier"
+            }
+          }
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add host to downstream request",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -8,6 +8,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add x-fapi-interaction-id header if one was not present in the request",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -12,6 +12,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Add a detached signature to the response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -7,6 +7,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/68-ob-aggregated-polling.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/68-ob-aggregated-polling.json
@@ -11,6 +11,10 @@
     "type": "Chain",
     "config": {
       "filters": [
+        {
+          "name": "RouteMetricsFilter",
+          "type": "RouteMetricsFilter"
+        },
         "SBATFapiInteractionFilterChain",
         {
           "comment": "Ensure OB compliant response",

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -23,6 +23,7 @@ import org.forgerock.openig.alias.ClassAliasResolver;
 import com.forgerock.sapi.gateway.am.ReSignIdTokenFilter;
 import com.forgerock.sapi.gateway.common.exception.SapiLogAttachedExceptionFilterHeaplet;
 import com.forgerock.sapi.gateway.consent.ConsentRequestAccessAuthorisationFilter;
+import com.forgerock.sapi.gateway.dcr.idm.AuthorizeResponseFetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.request.RegistrationRequestEntityValidatorFilter;
 import com.forgerock.sapi.gateway.dcr.sigvalidation.RegistrationRequestJwtSignatureValidationFilter;
@@ -32,6 +33,8 @@ import com.forgerock.sapi.gateway.jwks.RestJwkSetService;
 import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCachingJwkSetService;
 import com.forgerock.sapi.gateway.jws.RsaJwtSignatureValidator;
 import com.forgerock.sapi.gateway.jws.signer.CompactSerializationJwsSigner;
+import com.forgerock.sapi.gateway.metrics.RouteMetricsFilter;
+import com.forgerock.sapi.gateway.metrics.TokenEndpointMetricsContextSupplier;
 import com.forgerock.sapi.gateway.mtls.AddCertificateToAttributesContextFilter;
 import com.forgerock.sapi.gateway.mtls.DefaultTransportCertValidator;
 import com.forgerock.sapi.gateway.mtls.ContextCertificateRetriever;
@@ -65,6 +68,9 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("AddCertificateToAttributesContextFilter", AddCertificateToAttributesContextFilter.class);
         ALIASES.put("ContextCertificateRetriever", ContextCertificateRetriever.class);
         ALIASES.put("HeaderCertificateRetriever", HeaderCertificateRetriever.class);
+        ALIASES.put("RouteMetricsFilter", RouteMetricsFilter.class);
+        ALIASES.put("AuthoriseResponseFetchApiClientFilter", AuthorizeResponseFetchApiClientFilter.class);
+        ALIASES.put("TokenEndpointMetricsContextSupplier", TokenEndpointMetricsContextSupplier.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr.idm;
+
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+
+import java.util.List;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.Reject;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.dcr.idm.ApiClientService.ApiClientServiceException;
+import com.forgerock.sapi.gateway.dcr.idm.ApiClientService.ApiClientServiceException.ErrorCode;
+import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter.BaseFetchApiClientHeaplet;
+import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+
+/**
+ * Implementation of the {@link FetchApiClientFilter} which is specialised for use in an IG route reverse proxying an
+ * OAuth2 authorization endpoint implemented as per <a href="https://www.rfc-editor.org/info/rfc6749">RFC 6749</a>
+ * <p>
+ * The client_id request URI parameter is used to retrieve the {@link ApiClient} which is then made accessible via the
+ * AttributesContext as key: "apiClient", other filters in the chain can then access this data using the context.
+ * <p>
+ * This implementation runs on the response path (rather than the request path), this ensures that the AS has
+ * successfully authenticated the client before fetching the ApiClient data
+ */
+public class AuthorizeResponseFetchApiClientFilter implements Filter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Service which can retrieve ApiClient data
+     */
+    private final ApiClientService apiClientService;
+
+    public AuthorizeResponseFetchApiClientFilter(ApiClientService apiClientService) {
+        this.apiClientService = Reject.checkNotNull(apiClientService, "apiClientService must be provided");
+    }
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler next) {
+        return next.handle(context, request).thenAsync(response -> {
+            if (response.getStatus().isServerError() || response.getStatus().isClientError()) {
+                return Promises.newResultPromise(response);
+            } else {
+                final List<String> clientIdParams = request.getQueryParams().get("client_id");
+                final String clientId;
+                if (clientIdParams != null && clientIdParams.size() > 0) {
+                    clientId =  clientIdParams.get(0);
+                } else {
+                    logger.error("Authorize request missing mandatory client_id param");
+                    return Promises.newResultPromise(new Response(Status.INTERNAL_SERVER_ERROR));
+                }
+                return apiClientService.getApiClient(clientId)
+                                       .thenOnResult(FetchApiClientFilter.createAddApiClientToContextResultHandler(context, logger))
+                                       .then(apiClient -> response, // return the original response from the upstream
+                                             this::handleApiClientServiceException, this::handleUnexpectedException);
+
+            }
+        });
+    }
+
+    private Response handleApiClientServiceException(ApiClientServiceException ex) {
+        // Handles the case where the ApiClient has been deleted from the data store
+        if (ex.getErrorCode() == ErrorCode.DELETED || ex.getErrorCode() == ErrorCode.NOT_FOUND) {
+            logger.warn("Failed to get ApiClient due to: {}", ex.getErrorCode(), ex);
+            return new Response(Status.UNAUTHORIZED).setEntity(json(field("error", "client registration is invalid")));
+        } else {
+            return handleUnexpectedException(ex);
+        }
+    }
+
+    private Response handleUnexpectedException(Exception ex) {
+        logger.error("Failed to get ApiClient from idm due to an unexpected exception", ex);
+        return new Response(Status.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Responsible for creating the {@link AuthorizeResponseFetchApiClientFilter}
+     *
+     * Mandatory config:
+     * - idmGetApiClientBaseUri: the base uri used to build the IDM query to get the apiClient, the client_id is expected
+     * to be appended to this uri (and some query params).
+     * - clientHandler: the clientHandler to use to call out to IDM (must be configured with the credentials required to
+     * query IDM)
+     *
+     * Example config:
+     * {
+     *           "comment": "Add ApiClient data to the context attributes for the AS /authorize route",
+     *           "name": "AuthoriseResponseFetchApiClientFilter",
+     *           "type": "AuthoriseResponseFetchApiClientFilter",
+     *           "config": {
+     *             "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",
+     *             "clientHandler": "IDMClientHandler"
+     *            }
+     * }
+     */
+    public static class Heaplet extends BaseFetchApiClientHeaplet {
+        @Override
+        public Object create() throws HeapException {
+            return new AuthorizeResponseFetchApiClientFilter(createApiClientService());
+        }
+    }
+
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisher.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisher.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.forgerock.http.util.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link RouteMetricsEventPublisher} which publishes metrics to a {@link org.slf4j.Logger}
+ * <p>
+ * The publisher passes raw json to the logger, therefore it is recommended to configure the Logger for this class
+ * to use an appender which does not apply any decoration to messages.
+ * <p>
+ * Example logback config:
+ * <pre>
+ * {@code
+ * <appender name="METRICS" class="ch.qos.logback.core.ConsoleAppender">
+ *     <encoder>
+ *         <pattern>%msg%n</pattern>
+ *     </encoder>
+ * </appender>
+ * <logger name="com.forgerock.sapi.gateway.metrics.LoggerRouteMetricsEventPublisher" additivity="false">
+ *      <appender-ref ref="METRICS" />
+ * </logger>
+ * }
+ * </pre>
+ */
+public class LoggerRouteMetricsEventPublisher implements RouteMetricsEventPublisher {
+
+    /**
+     * Logger to write the {@link RouteMetricsEvent}s to
+     */
+    private final Logger metricsLogger;
+
+    /**
+     * Logger for errors produced writing metrics.
+     * This is needed in order to keep error messages separate from the actual metrics.
+     */
+    private final Logger errorLogger = LoggerFactory.getLogger(LoggerRouteMetricsEventPublisher.class.getSimpleName() + "-error");
+
+    public LoggerRouteMetricsEventPublisher() {
+        this(LoggerFactory.getLogger(LoggerRouteMetricsEventPublisher.class));
+    }
+
+    public LoggerRouteMetricsEventPublisher(Logger metricsLogger) {
+        this.metricsLogger = metricsLogger;
+    }
+
+    @Override
+    public void publish(RouteMetricsEvent routeMetricsEvent) {
+        try {
+            metricsLogger.info("{}", new String(Json.writeJson(routeMetricsEvent), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            errorLogger.error("Json.writeJson failed due to exception", e);
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/MetricsContextSupplier.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/MetricsContextSupplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.forgerock.http.protocol.Request;
+import org.forgerock.services.context.Context;
+
+/**
+ * Supplies context data to store in the RouteMetricsEvent.context field.
+ * <p>
+ * This data is optional, it allows routes to supply additional custom contextual information about a request.
+ */
+public interface MetricsContextSupplier {
+
+    /**
+     * Implementation which returns an empty context, this can be used for routes which do not have any context
+     * information to report.
+     */
+    MetricsContextSupplier EMPTY_CONTEXT_SUPPLIER = (requestContext, request) -> Collections.emptyMap();
+
+    /**
+     * Extract Metrics Context information for the given HTTP Request and Request Context.
+     *
+     * @param requestContext HTTP request's Context which may be used to extract metrics context information from
+     * @param request        HTTP request which may be used to extract metrics context information from
+     * @return Map<String, Object> the metrics context information for this request, NOTE: must be serializable to JSON using
+     * the {@link org.forgerock.http.util.Json#writeJson(Object)} method. When there is no context information to report
+     * then an empty Map should be returned.
+     */
+    Map<String, Object> getMetricsContext(Context requestContext, Request request);
+
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEvent.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEvent.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import java.util.Map;
+
+/**
+ * RouteMetricsEvent represents the metrics data gathered when a request has been processed by a particular route
+ */
+public class RouteMetricsEvent {
+
+    /**
+     * Unix epoch timestamp in milliseconds representing the time at which the event was created
+     */
+    private long timestamp;
+    /**
+     * Description of the type of this event e.g. route-metrics
+     */
+    private String eventType;
+    /**
+     * IG routeId of the route which produced the event
+     */
+    private String routeId;
+    /**
+     * Path portion of the request URI
+     */
+    private String requestPath;
+    /**
+     * HTTP method of the request
+     */
+    private String httpMethod;
+    /**
+     * Time to process the request and produce a response
+     */
+    private long responseTimeMillis;
+    /**
+     * HTTP Status Code of the response
+     */
+    private int httpStatusCode;
+    /**
+     * Flag indicating if the httpStatusCode represents a success or not.
+     */
+    private boolean successResponse;
+    /**
+     * The id of the ApiClient making the request
+     */
+    private String apiClientId;
+    /**
+     * The id of the ApiClientOrganisation that the ApiClient belongs to
+     */
+    private String apiClientOrgId;
+    /**
+     * Name of the trustedDirectory that the ApiClient is registered with
+     */
+    private String trustedDirectory;
+    /**
+     * Custom contextual information which may be supplied on a per-request basis
+     */
+    private Map<String, Object> context;
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getRouteId() {
+        return routeId;
+    }
+
+    public String getRequestPath() {
+        return requestPath;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public long getResponseTimeMillis() {
+        return responseTimeMillis;
+    }
+
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    public boolean isSuccessResponse() {
+        return successResponse;
+    }
+
+    public String getApiClientId() {
+        return apiClientId;
+    }
+
+    public String getApiClientOrgId() {
+        return apiClientOrgId;
+    }
+
+    public String getTrustedDirectory() {
+        return trustedDirectory;
+    }
+
+    public Map<String, Object> getContext() {
+        return context;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public void setRouteId(String routeId) {
+        this.routeId = routeId;
+    }
+
+    public void setRequestPath(String requestPath) {
+        this.requestPath = requestPath;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public void setResponseTimeMillis(long responseTimeMillis) {
+        this.responseTimeMillis = responseTimeMillis;
+    }
+
+    public void setHttpStatusCode(int httpStatusCode) {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public void setSuccessResponse(boolean successResponse) {
+        this.successResponse = successResponse;
+    }
+
+    public void setApiClientId(String apiClientId) {
+        this.apiClientId = apiClientId;
+    }
+
+    public void setApiClientOrgId(String apiClientOrgId) {
+        this.apiClientOrgId = apiClientOrgId;
+    }
+
+    public void setTrustedDirectory(String trustedDirectory) {
+        this.trustedDirectory = trustedDirectory;
+    }
+
+    public void setContext(Map<String, Object> context) {
+        this.context = context;
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEventPublisher.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEventPublisher.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+/**
+ * Publisher of {@link RouteMetricsEvent} objects.
+ * <p>
+ * Metrics are reported on the hot code path, therefore publisher implementations should be fast and avoid throwing
+ * exceptions.
+ */
+public interface RouteMetricsEventPublisher {
+
+    /**
+     * @param routeMetricsEvent {@link RouteMetricsEvent} to publish
+     */
+    void publish(RouteMetricsEvent routeMetricsEvent);
+
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import static org.forgerock.openig.util.JsonValues.optionalHeapObject;
+import static org.forgerock.util.Reject.checkNotNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.openig.handler.router.RoutingContext;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
+
+/**
+ * This filter is responsible for reporting metrics for the route that it is configured in. The metrics are published as
+ * {@link RouteMetricsEvent} objects, with one event being published per request processed by the route.
+ * <p>
+ * The filter should be installed as the first filter in the chain in order to get the most accurate response time data.
+ * <p>
+ * {@link RouteMetricsEvent} objects contain {@link ApiClient} metadata, this filter expects to find the ApiClient in
+ * the attributes context in the response path. This means that the attributes context needs to be populated correctly
+ * prior to this filter processing the response, typically this involves running the {@link FetchApiClientFilter}.
+ */
+public class RouteMetricsFilter implements Filter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Ticker is a nanosecond time source which is used to measure the response time using a {@link Stopwatch}
+     * See {@link Stopwatch#createStarted(Ticker)}
+     */
+    private final Ticker ticker;
+
+    /**
+     * Supplier of millisecond precision unix epoch timestamps
+     */
+    private final LongSupplier timestampSupplier;
+
+    /**
+     * Publisher of {@link RouteMetricsEvent} objects produced by this filter
+     */
+    private final RouteMetricsEventPublisher metricsEventPublisher;
+
+    /**
+     * Supplier of Metrics Context information which is extracted from the HTTP Request being processed
+     */
+    private final MetricsContextSupplier metricsContextSupplier;
+
+    public RouteMetricsFilter(Ticker ticker, LongSupplier timestampSupplier,
+                              RouteMetricsEventPublisher metricsEventPublisher,
+                              MetricsContextSupplier metricsContextSupplier) {
+        this.ticker = checkNotNull(ticker, "ticker must be provided");
+        this.timestampSupplier = checkNotNull(timestampSupplier, "timestampSupplier must be provided");
+        this.metricsEventPublisher = checkNotNull(metricsEventPublisher, "metricsEventPublisher must be provided");
+        this.metricsContextSupplier = checkNotNull(metricsContextSupplier, "metricsContextSupplier must be provided");
+    }
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler handler) {
+        final Stopwatch stopwatch = Stopwatch.createStarted(ticker);
+        final Map<String, Object> routeMetricsContext = getRouteMetricsContext(context, request);
+        return handler.handle(context, request).thenOnResult(response -> {
+            try {
+                metricsEventPublisher.publish(buildRouteMetricsEvent(stopwatch, context, request, response, routeMetricsContext));
+            } catch (RuntimeException ex) {
+                logger.error("Failed to publish metrics due to exception", ex);
+            }
+        });
+    }
+
+    private RouteMetricsEvent buildRouteMetricsEvent(Stopwatch stopwatch, Context context, Request request,
+                                                     Response response, Map<String, Object> metricsContext) {
+        final ApiClient apiClient = FetchApiClientFilter.getApiClientFromContext(context);
+
+        final RouteMetricsEvent metricEvent = new RouteMetricsEvent();
+        metricEvent.setTimestamp(timestampSupplier.getAsLong());
+        metricEvent.setContext(metricsContext);
+        metricEvent.setEventType("route-metrics");
+        metricEvent.setRouteId(getRouteId(context));
+        metricEvent.setHttpMethod(request.getMethod());
+        metricEvent.setRequestPath(request.getUri().getPath());
+        metricEvent.setApiClientId(getApiClientId(apiClient));
+        metricEvent.setApiClientOrgId(getApiClientOrgId(apiClient));
+        metricEvent.setTrustedDirectory(getTrustedDirectory(apiClient));
+        metricEvent.setHttpStatusCode(response.getStatus().getCode());
+        metricEvent.setSuccessResponse(isSuccessResponse(response.getStatus()));
+
+        stopwatch.stop();
+        metricEvent.setResponseTimeMillis(stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        return metricEvent;
+    }
+
+    private Map<String, Object> getRouteMetricsContext(Context context, Request request) {
+        try {
+            final Map<String, Object> metricsContext = metricsContextSupplier.getMetricsContext(context, request);
+            if (metricsContext != null) {
+                return metricsContext;
+            }
+        } catch (RuntimeException ex) {
+            logger.error("Unexpected exception thrown invoking metricsContextSupplier", ex);
+        }
+        return Collections.emptyMap();
+    }
+
+    /**
+     * @param responseStatus Status of the Response object
+     * @return boolean which indicates whether the Response is deemed a success or not. A success is any response that
+     * is not a 4xx or 5xx.
+     */
+    static boolean isSuccessResponse(Status responseStatus) {
+        return !(responseStatus.isClientError() || responseStatus.isServerError());
+    }
+
+    static String getApiClientId(ApiClient apiClient) {
+        if (apiClient == null) {
+            return null;
+        } else {
+            return apiClient.getOauth2ClientId();
+        }
+    }
+
+    static String getApiClientOrgId(ApiClient apiClient) {
+        if (apiClient == null) {
+            return null;
+        } else {
+            if (apiClient.getOrganisation() == null) {
+                return null;
+            } else {
+                return apiClient.getOrganisation().getId();
+            }
+        }
+    }
+
+    static String getTrustedDirectory(ApiClient apiClient) {
+        if (apiClient == null) {
+            return null;
+        } else {
+            return TrustedDirectoryService.getTrustedDirectoryIssuerName(apiClient);
+        }
+    }
+
+    private static String getRouteId(Context context) {
+        return context.as(RoutingContext.class)
+                      .map(RoutingContext::getRouteId)
+                      .orElse(null);
+    }
+
+    /**
+     * Heaplet responsible for constructing {@link RouteMetricsFilter}
+     * <p>
+     * Optional config:
+     * <p>
+     * - metricsContextSupplier an instance of {@link MetricsContextSupplier} found on the heap, this extracts custom
+     *                          request specific metrics contextual information. Example implementation: {@link TokenEndpointMetricsContextSupplier}
+     *                          Defaults to: MetricsContextSupplier.EMPTY_CONTEXT_SUPPLIER which supplies no context information
+     * <pre>
+     * Example config:
+     * {
+     *             "name": "RouteMetricsFilter",
+     *             "type": "RouteMetricsFilter",
+     *             "comment": "Filter for reporting request metrics to the log file"
+     * }
+     * </pre>
+     */
+    public static class Heaplet extends GenericHeaplet {
+
+        @Override
+        public Object create() throws HeapException {
+
+            MetricsContextSupplier metricsContextSupplier = config.get("metricsContextSupplier")
+                                                                  .as(optionalHeapObject(heap, MetricsContextSupplier.class));
+            if (metricsContextSupplier == null) {
+                metricsContextSupplier = MetricsContextSupplier.EMPTY_CONTEXT_SUPPLIER;
+            }
+
+            return new RouteMetricsFilter(Ticker.systemTicker(),
+                                          System::currentTimeMillis,
+                                          new LoggerRouteMetricsEventPublisher(),
+                                          metricsContextSupplier);
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/TokenEndpointMetricsContextSupplier.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/TokenEndpointMetricsContextSupplier.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.forgerock.http.protocol.Request;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Supplies Context information for the Token Endpoint route.
+ * <p>
+ * The context contains a single field: "grant_type" which is extracted from the Request's form parameter of the same
+ * name. This represents the OAuth2.0 grant_type of the token that is being requested.
+ */
+public class TokenEndpointMetricsContextSupplier implements MetricsContextSupplier {
+
+    private static final String GRANT_TYPE = "grant_type";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Map<String, Object> getMetricsContext(Context requestContext, Request request) {
+        final String grantType = getGrantType(request);
+        if (grantType != null) {
+            return Map.of("grant_type", grantType);
+        }
+        return Collections.emptyMap();
+    }
+
+    private String getGrantType(Request request) {
+        final List<String> grantTypeParams;
+        try {
+            grantTypeParams = request.getEntity().getForm().get(GRANT_TYPE);
+            if (grantTypeParams != null && grantTypeParams.size() > 0) {
+                return grantTypeParams.get(0);
+            }
+        } catch (IOException e) {
+            logger.error("Failed to get grant_type from request form", e);
+        }
+        return null;
+    }
+
+    public static class Heaplet extends GenericHeaplet {
+        @Override
+        public Object create() throws HeapException {
+            return new TokenEndpointMetricsContextSupplier();
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/package-info.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package provides functionality for capturing and publishing metrics.
+ */
+package com.forgerock.sapi.gateway.metrics;

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryService.java
@@ -30,9 +30,18 @@ public interface TrustedDirectoryService {
      * no value is held for the issuer.
      */
     default TrustedDirectory getTrustedDirectoryConfiguration(ApiClient apiClient) {
-        final JwtClaimsSet ssaClaims = apiClient.getSoftwareStatementAssertion().getClaimsSet();
-        final String issuer = ssaClaims.getIssuer();
-        return getTrustedDirectoryConfiguration(issuer);
+        return getTrustedDirectoryConfiguration(getTrustedDirectoryIssuerName(apiClient));
+    }
+
+    /**
+     * Helper method to get the issuer name of the TrustedDirectory for an ApiClient instance.
+     * An ApiClient has been created from a Software Statement issued by a Trusted Directory.
+     *
+     * @param apiClient ApiClient to get {@link TrustedDirectory} for
+     * @return The issuer name of the {@code TrustedDirectory} associated with the ApiClient's Software Statement
+     */
+    static String getTrustedDirectoryIssuerName(ApiClient apiClient) {
+        return apiClient.getSoftwareStatementAssertion().getClaimsSet().getIssuer();
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilterTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr.idm;
+
+import static com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilterTest.createApiClientService;
+import static com.forgerock.sapi.gateway.dcr.idm.IdmApiClientDecoderTest.createIdmApiClientDataAllFields;
+import static com.forgerock.sapi.gateway.dcr.idm.IdmApiClientDecoderTest.createIdmApiClientDataRequiredFieldsOnly;
+import static com.forgerock.sapi.gateway.dcr.idm.IdmApiClientDecoderTest.verifyIdmClientDataMatchesApiClientObject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+
+import org.forgerock.http.Client;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueException;
+import org.forgerock.openig.handler.Handlers;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.openig.heap.HeapImpl;
+import org.forgerock.openig.heap.Name;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.RootContext;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.dcr.idm.AuthorizeResponseFetchApiClientFilter.Heaplet;
+import com.forgerock.sapi.gateway.dcr.idm.IdmApiClientServiceTest.MockApiClientTestDataIdmHandler;
+import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.util.TestHandlers.FixedResponseHandler;
+import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
+
+class AuthorizeResponseFetchApiClientFilterTest {
+
+    static final String idmBaseUri = "http://localhost/openidm/managed/";
+    static final String clientId = "9999";
+
+
+    @Test
+    void fetchApiClientForSuccessResponse() throws Exception {
+        final JsonValue idmClientData = createIdmApiClientDataRequiredFieldsOnly(clientId);
+        final MockApiClientTestDataIdmHandler idmResponseHandler = new MockApiClientTestDataIdmHandler(idmBaseUri, clientId, idmClientData);
+        final AuthorizeResponseFetchApiClientFilter filter = new AuthorizeResponseFetchApiClientFilter(createApiClientService(new Client(idmResponseHandler), idmBaseUri));
+        callFilterValidateSuccessBehaviour(idmClientData, filter);
+    }
+
+    private static void callFilterValidateSuccessBehaviour(JsonValue idmClientData, AuthorizeResponseFetchApiClientFilter filter) throws Exception {
+
+        final BiConsumer<Response, AttributesContext> successBehaviourValidator = (response, ctxt) -> {
+            // Verify we hit the end of the chain and got the NO_CONTENT response
+            assertEquals(Status.NO_CONTENT, response.getStatus());
+
+            // Verify that the context was updated with the apiClient data
+            final ApiClient apiClient = FetchApiClientFilter.getApiClientFromContext(ctxt);
+            assertNotNull(apiClient, "apiClient was not found in context");
+            verifyIdmClientDataMatchesApiClientObject(idmClientData, apiClient);
+        };
+        callFilter(filter, successBehaviourValidator);
+    }
+
+    private static void callFilter(AuthorizeResponseFetchApiClientFilter filter, BiConsumer<Response, AttributesContext> responseAndContextValidator) throws Exception {
+        final AttributesContext attributesContext = createContext();
+
+        // This is the next handler called after the AuthoriseResponseFetchApiClientFilter
+        final Handler endOfFilterChainHandler = Handlers.NO_CONTENT;
+        final Request request = createRequest();
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(attributesContext, request, endOfFilterChainHandler);
+
+        final Response response = responsePromise.getOrThrow(1L, TimeUnit.SECONDS);
+
+        // Do the validation
+        responseAndContextValidator.accept(response, attributesContext);
+    }
+
+    private static Request createRequest() {
+        final Request request = new Request();
+        try {
+            request.setUri("/authorize?client_id=" + clientId);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        return request;
+    }
+
+    private static AttributesContext createContext() {
+        return new AttributesContext(new RootContext("root"));
+    }
+
+    @Test
+    void doesNotFetchApiClientForErrorResponses() throws InterruptedException, TimeoutException {
+        final JsonValue idmClientData = createIdmApiClientDataRequiredFieldsOnly(clientId);
+        final MockApiClientTestDataIdmHandler idmResponseHandler = new MockApiClientTestDataIdmHandler(idmBaseUri, clientId, idmClientData);
+        final AuthorizeResponseFetchApiClientFilter filter = new AuthorizeResponseFetchApiClientFilter(createApiClientService(new Client(idmResponseHandler), idmBaseUri));
+        final AttributesContext context = createContext();
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, createRequest(), new FixedResponseHandler(new Response(Status.BAD_GATEWAY)));
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(response.getStatus()).isEqualTo(Status.BAD_GATEWAY);
+        assertThat(FetchApiClientFilter.getApiClientFromContext(context)).isNull();
+    }
+
+    @Test
+    void returnsErrorResponseWhenClientIdParamNotFound() throws Exception {
+        final JsonValue idmClientData = createIdmApiClientDataRequiredFieldsOnly(clientId);
+        final MockApiClientTestDataIdmHandler idmResponseHandler = new MockApiClientTestDataIdmHandler(idmBaseUri, clientId, idmClientData);
+        final AuthorizeResponseFetchApiClientFilter filter = new AuthorizeResponseFetchApiClientFilter(createApiClientService(new Client(idmResponseHandler), idmBaseUri));
+        final AttributesContext context = createContext();
+
+        final Request request = new Request();
+        request.setUri("/authorize");
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, new TestSuccessResponseHandler());
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(response.getStatus()).isEqualTo(Status.INTERNAL_SERVER_ERROR);
+        assertThat(FetchApiClientFilter.getApiClientFromContext(context)).isNull();
+    }
+
+    @Test
+    void returnsErrorResponseWhenApiClientServiceReturnsException() throws Exception {
+        final AuthorizeResponseFetchApiClientFilter filter = new AuthorizeResponseFetchApiClientFilter(createApiClientService(new Client(Handlers.INTERNAL_SERVER_ERROR), idmBaseUri));
+        final AttributesContext context = createContext();
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, createRequest(), new TestSuccessResponseHandler());
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(response.getStatus()).isEqualTo(Status.INTERNAL_SERVER_ERROR);
+        assertThat(FetchApiClientFilter.getApiClientFromContext(context)).isNull();
+    }
+
+    @Nested
+    public class HeapletTests {
+        @Test
+        void failsToConstructIfClientHandlerIsMissing() {
+            final HeapException heapException = assertThrows(HeapException.class, () -> new Heaplet().create(Name.of("test"),
+                    json(object()), new HeapImpl(Name.of("heap"))), "Invalid object declaration");
+            assertEquals(heapException.getCause().getMessage(), "/clientHandler: Expecting a value");
+        }
+
+        @Test
+        void failsToConstructIfIdmUrlIsMissing() {
+            final Handler idmClientHandler = (ctx, req) -> Promises.newResultPromise(new Response(Status.OK));
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            heap.put("idmClientHandler", idmClientHandler);
+
+            assertThrows(JsonValueException.class, () -> new Heaplet().create(Name.of("test"),
+                    json(object(field("clientHandler", "idmClientHandler"))), heap), "/idmGetApiClientBaseUri: Expecting a value");
+        }
+
+        @Test
+        void successfullyCreatesFilterWithRequiredConfigOnly() throws Exception {
+            final JsonValue idmApiClientData = createIdmApiClientDataAllFields(clientId);
+            final Handler idmClientHandler = new MockApiClientTestDataIdmHandler(idmBaseUri, clientId, idmApiClientData);
+
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            heap.put("idmClientHandler", idmClientHandler);
+
+            final JsonValue config = json(object(field("clientHandler", "idmClientHandler"),
+                    field("idmGetApiClientBaseUri", idmBaseUri)));
+            final AuthorizeResponseFetchApiClientFilter filter = (AuthorizeResponseFetchApiClientFilter) new Heaplet().create(Name.of("test"), config, heap);
+
+            // Test the filter created by the Heaplet
+            callFilterValidateSuccessBehaviour(idmApiClientData, filter);
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/FetchApiClientFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/FetchApiClientFilterTest.java
@@ -86,7 +86,7 @@ class FetchApiClientFilterTest {
         callFilterValidateSuccessBehaviour(accessToken, idmClientData, filter);
     }
 
-    private static ApiClientService createApiClientService(Client client, String idmBaseUri) {
+    public static ApiClientService createApiClientService(Client client, String idmBaseUri) {
         return new IdmApiClientService(client, idmBaseUri, new IdmApiClientDecoder());
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisherTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisherTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class LoggerRouteMetricsEventPublisherTest {
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private LoggerRouteMetricsEventPublisher loggerRouteMetricPublisher;
+
+    @Test
+    void testPublishAsJson() throws JsonProcessingException {
+        final RouteMetricsEvent routeMetricsEvent = new RouteMetricsEvent();
+        routeMetricsEvent.setEventType("test-event");
+        routeMetricsEvent.setRouteId("test-route-id");
+        routeMetricsEvent.setContext(Map.of("extraField1", "value1", "extraField2", 2));
+        routeMetricsEvent.setHttpMethod("GET");
+        routeMetricsEvent.setRequestPath("/test/metrics");
+        routeMetricsEvent.setResponseTimeMillis(344334);
+        routeMetricsEvent.setSuccessResponse(true);
+        routeMetricsEvent.setHttpStatusCode(201);
+        routeMetricsEvent.setApiClientId("api-client-1");
+        routeMetricsEvent.setApiClientOrgId("api-client-org-1");
+        routeMetricsEvent.setTimestamp(100000);
+        routeMetricsEvent.setTrustedDirectory("OpenBankingUK");
+
+        ArgumentCaptor<String> jsonArgumentCapture = ArgumentCaptor.forClass(String.class);
+        doNothing().when(logger).info(anyString(), jsonArgumentCapture.capture());
+
+        loggerRouteMetricPublisher.publish(routeMetricsEvent);
+
+        final String loggedJson = jsonArgumentCapture.getValue();
+        final RouteMetricsEvent loggedEvent = new ObjectMapper().readValue(loggedJson, RouteMetricsEvent.class);
+        assertThat(loggedEvent).usingRecursiveComparison().isEqualTo(routeMetricsEvent);
+    }
+
+    @Test
+    void gracefullyHandlesPublishException() {
+        final RouteMetricsEvent routeMetricsEvent = new RouteMetricsEvent();
+        // Context allows any data to be plugged into the metrics event, add something which Jackson cannot serialize to trigger an exception
+        routeMetricsEvent.setContext(Map.of("extraField1", Runtime.getRuntime()));
+
+        // No Exception is thrown
+        loggerRouteMetricPublisher.publish(routeMetricsEvent);
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilterTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.openig.handler.router.RoutingContext;
+import org.forgerock.openig.heap.HeapImpl;
+import org.forgerock.openig.heap.Name;
+import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.metrics.RouteMetricsFilter.Heaplet;
+import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilterTest;
+import com.forgerock.sapi.gateway.util.TestHandlers.FixedResponseHandler;
+import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
+import com.google.common.base.Ticker;
+
+@ExtendWith(MockitoExtension.class)
+class RouteMetricsFilterTest {
+
+    public static final String TRUSTED_DIRECTORY_NAME = "OpenBankingUK";
+    private static final ApiClient TEST_API_CLIENT = FetchTrustedDirectoryFilterTest.createApiClient(TRUSTED_DIRECTORY_NAME);
+    private static final String TEST_ROUTE_ID = "01-test-route";
+
+    private static final Map<String, Object> EMPTY_METRICS_CONTEXT = Map.of();
+
+    @Mock
+    private RouteMetricsEventPublisher routeMetricsEventPublisher;
+
+    @Mock
+    private Ticker ticker;
+
+    private long timestampSourceInitialValue;
+
+    private AtomicLong timestampSource;
+
+    @BeforeEach
+    public void before() {
+        timestampSourceInitialValue = System.currentTimeMillis();
+        timestampSource = new AtomicLong(timestampSourceInitialValue);
+    }
+
+    @Test
+    void reportsRouteMetricsForSuccessResponse() throws Exception {
+        final long expectedResponseTime = 123L;
+        mockTickerForSingleResponseTime(expectedResponseTime);
+        final RouteMetricsFilter routeMetricsFilter = createFilter(timestampSource);
+
+        final Request request = new Request();
+        request.setUri("https://localhost/test/route");
+        request.setMethod("POST");
+
+        final ArgumentCaptor<RouteMetricsEvent> metricsEventCaptor = ArgumentCaptor.forClass(RouteMetricsEvent.class);
+        doNothing().when(routeMetricsEventPublisher).publish(metricsEventCaptor.capture());
+
+        final TestSuccessResponseHandler handler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(createContext(), request, handler);
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(handler.hasBeenInteractedWith()).isTrue();
+        assertThat(response.getStatus().isSuccessful()).isTrue();
+        final List<RouteMetricsEvent> metricsEvents = metricsEventCaptor.getAllValues();
+        assertThat(metricsEvents.size()).isEqualTo(1);
+        final RouteMetricsEvent metricsEvent = metricsEvents.get(0);
+
+        validateMetricsEvent(metricsEvent, timestampSourceInitialValue, expectedResponseTime,
+                "POST", "/test/route", 200, true, EMPTY_METRICS_CONTEXT);
+    }
+
+    @Test
+    void reportsRouteMetricsForErrorResponse() throws Exception {
+        final long expectedResponseTime = 233;
+        mockTickerForSingleResponseTime(expectedResponseTime);
+        final RouteMetricsFilter routeMetricsFilter = createFilter(timestampSource);
+
+        final Request request = new Request();
+        request.setUri("https://localhost/test/route/with/error");
+        request.setMethod("GET");
+
+        final ArgumentCaptor<RouteMetricsEvent> metricsEventCaptor = ArgumentCaptor.forClass(RouteMetricsEvent.class);
+        doNothing().when(routeMetricsEventPublisher).publish(metricsEventCaptor.capture());
+
+        final FixedResponseHandler handler = new FixedResponseHandler(new Response(Status.BAD_REQUEST));
+        final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(createContext(), request, handler);
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(handler.hasBeenInteractedWith()).isTrue();
+        assertThat(response.getStatus().isSuccessful()).isFalse();
+        final List<RouteMetricsEvent> metricsEvents = metricsEventCaptor.getAllValues();
+        assertThat(metricsEvents.size()).isEqualTo(1);
+        final RouteMetricsEvent metricsEvent = metricsEvents.get(0);
+
+        validateMetricsEvent(metricsEvent, timestampSourceInitialValue, expectedResponseTime,
+                "GET", "/test/route/with/error", 400, false, EMPTY_METRICS_CONTEXT);
+    }
+
+    // Failure to publish the metrics must not result in an error HTTP Response
+    @Test
+    void gracefullyHandlesMetricsPublisherFailure() throws Exception {
+        final long expectedResponseTime = 123L;
+        mockTickerForSingleResponseTime(expectedResponseTime);
+        final RouteMetricsFilter routeMetricsFilter = createFilter(timestampSource);
+
+        final Request request = new Request();
+        request.setUri("https://localhost/test/route");
+        request.setMethod("POST");
+
+        doThrow(new IllegalStateException("publisher failed!")).when(routeMetricsEventPublisher).publish(any());
+
+        final TestSuccessResponseHandler handler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(createContext(), request, handler);
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(handler.hasBeenInteractedWith()).isTrue();
+        assertThat(response.getStatus().isSuccessful()).isTrue();
+    }
+
+    @Test
+    void reportsCustomMetricsContextInformation() throws Exception {
+        final long expectedResponseTime = 123L;
+        mockTickerForSingleResponseTime(expectedResponseTime);
+
+        final Map<String, Object> customMetricsContextData = Map.of("customInfo", 123, "field2", "value2");
+        final MetricsContextSupplier customMetricsContextSupplier = (context, request) -> customMetricsContextData;
+        final RouteMetricsFilter routeMetricsFilter = createFilter(timestampSource, customMetricsContextSupplier);
+
+        final Request request = new Request();
+        request.setUri("https://localhost/test/route");
+        request.setMethod("POST");
+
+        final ArgumentCaptor<RouteMetricsEvent> metricsEventCaptor = ArgumentCaptor.forClass(RouteMetricsEvent.class);
+        doNothing().when(routeMetricsEventPublisher).publish(metricsEventCaptor.capture());
+
+        final TestSuccessResponseHandler handler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(createContext(), request, handler);
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(handler.hasBeenInteractedWith()).isTrue();
+        assertThat(response.getStatus().isSuccessful()).isTrue();
+        final List<RouteMetricsEvent> metricsEvents = metricsEventCaptor.getAllValues();
+        assertThat(metricsEvents.size()).isEqualTo(1);
+        final RouteMetricsEvent metricsEvent = metricsEvents.get(0);
+
+        validateMetricsEvent(metricsEvent, timestampSourceInitialValue, expectedResponseTime,
+                "POST", "/test/route", 200, true, customMetricsContextData);
+    }
+
+    @Test
+    void gracefullyHandlesMetricsContextSupplierFailure() throws Exception {
+        MetricsContextSupplier buggyMetricsContextSupplier = (context, request) -> {
+            throw new IllegalStateException("error");
+        };
+
+        final long expectedResponseTime = 123L;
+        mockTickerForSingleResponseTime(expectedResponseTime);
+        final RouteMetricsFilter routeMetricsFilter = createFilter(timestampSource, buggyMetricsContextSupplier);
+
+        final Request request = new Request();
+        request.setUri("https://localhost/test/route");
+        request.setMethod("POST");
+
+        final ArgumentCaptor<RouteMetricsEvent> metricsEventCaptor = ArgumentCaptor.forClass(RouteMetricsEvent.class);
+        doNothing().when(routeMetricsEventPublisher).publish(metricsEventCaptor.capture());
+
+        final TestSuccessResponseHandler handler = new TestSuccessResponseHandler();
+        final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(createContext(), request, handler);
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(handler.hasBeenInteractedWith()).isTrue();
+        assertThat(response.getStatus().isSuccessful()).isTrue();
+        final List<RouteMetricsEvent> metricsEvents = metricsEventCaptor.getAllValues();
+        assertThat(metricsEvents.size()).isEqualTo(1);
+        final RouteMetricsEvent metricsEvent = metricsEvents.get(0);
+
+        validateMetricsEvent(metricsEvent, timestampSourceInitialValue, expectedResponseTime,
+                "POST", "/test/route", 200, true, EMPTY_METRICS_CONTEXT);
+    }
+
+    @Test
+    void shouldUseNullIfApiClientIsMissing() throws Exception {
+        final long expectedResponseTime = 233;
+        mockTickerForSingleResponseTime(expectedResponseTime);
+        final RouteMetricsFilter routeMetricsFilter = createFilter(timestampSource);
+
+        final Request request = new Request();
+        request.setUri("https://localhost/test/route/with/error");
+        request.setMethod("GET");
+
+        final ArgumentCaptor<RouteMetricsEvent> metricsEventCaptor = ArgumentCaptor.forClass(RouteMetricsEvent.class);
+        doNothing().when(routeMetricsEventPublisher).publish(metricsEventCaptor.capture());
+
+        final FixedResponseHandler handler = new FixedResponseHandler(new Response(Status.BAD_REQUEST));
+        final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(
+                createContext(null, TEST_ROUTE_ID), request, handler);
+        final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+        assertThat(handler.hasBeenInteractedWith()).isTrue();
+        assertThat(response.getStatus().isSuccessful()).isFalse();
+        final List<RouteMetricsEvent> metricsEvents = metricsEventCaptor.getAllValues();
+        assertThat(metricsEvents.size()).isEqualTo(1);
+        final RouteMetricsEvent metricsEvent = metricsEvents.get(0);
+
+        validateMetricsEventCoreFields(metricsEvent, timestampSourceInitialValue, expectedResponseTime,
+                "GET", "/test/route/with/error", 400, false, EMPTY_METRICS_CONTEXT);
+        assertThat(metricsEvent.getApiClientId()).isEqualTo(null);
+        assertThat(metricsEvent.getApiClientOrgId()).isEqualTo(null);
+        assertThat(metricsEvent.getTrustedDirectory()).isEqualTo(null);
+    }
+
+    @Test
+    void testSuccessResponseStatusMappings() {
+        Map<Status, Boolean> statusToSuccessResponse = Map.of(
+                Status.OK, TRUE,
+                Status.CREATED, TRUE,
+                Status.NO_CONTENT, TRUE,
+                Status.CONTINUE, TRUE,
+                Status.FOUND, TRUE,
+                Status.BAD_REQUEST, FALSE,
+                Status.UNAUTHORIZED, FALSE,
+                Status.FORBIDDEN, FALSE,
+                Status.INTERNAL_SERVER_ERROR, FALSE,
+                Status.BAD_GATEWAY, FALSE);
+
+        statusToSuccessResponse.forEach((status, expectedResult) ->
+                assertThat(RouteMetricsFilter.isSuccessResponse(status)).isEqualTo(expectedResult));
+    }
+
+    @Test
+    void testGetApiClientId() {
+        assertThat(RouteMetricsFilter.getApiClientId(TEST_API_CLIENT)).isEqualTo(TEST_API_CLIENT.getOauth2ClientId());
+        assertThat(RouteMetricsFilter.getApiClientId(null)).isEqualTo(null);
+    }
+
+    @Test
+    void testGetApiClientOrgId() {
+        assertThat(RouteMetricsFilter.getApiClientOrgId(TEST_API_CLIENT)).isEqualTo(TEST_API_CLIENT.getOrganisation().getId());
+        assertThat(RouteMetricsFilter.getApiClientOrgId(mock(ApiClient.class))).isEqualTo(null);
+        assertThat(RouteMetricsFilter.getApiClientOrgId(null)).isEqualTo(null);
+    }
+
+    @Test
+    void testGetTrustedDirectory() {
+        assertThat(RouteMetricsFilter.getTrustedDirectory(TEST_API_CLIENT))
+                .isEqualTo(TEST_API_CLIENT.getSoftwareStatementAssertion().getClaimsSet().getIssuer());
+        assertThat(RouteMetricsFilter.getTrustedDirectory(null)).isEqualTo(null);
+    }
+
+    private static Context createContext() {
+        return createContext(TEST_API_CLIENT, TEST_ROUTE_ID);
+    }
+
+    private static Context createContext(ApiClient apiClient, String routeId) {
+        final AttributesContext attributesContext = new AttributesContext(new RootContext("test"));
+        attributesContext.getAttributes().put(FetchApiClientFilter.API_CLIENT_ATTR_KEY, apiClient);
+        return new RoutingContext(attributesContext, routeId, "test-route-name");
+    }
+
+    private void mockTickerForSingleResponseTime(long responseTimeMillis) {
+        when(ticker.read()).thenReturn(0L, TimeUnit.MILLISECONDS.toNanos(responseTimeMillis));
+    }
+
+    private static void validateMetricsEvent(RouteMetricsEvent metricsEvent, long expectedTimestamp,
+            long expectedResponseTime, String expectedHttpMethod, String expectedRequestPath,
+            int expectedStatusCode, boolean isSuccessResponse, Map<String, Object> expectedMetricsContext) {
+
+        validateMetricsEventCoreFields(metricsEvent, expectedTimestamp, expectedResponseTime, expectedHttpMethod,
+                expectedRequestPath, expectedStatusCode, isSuccessResponse, expectedMetricsContext);
+        assertThat(metricsEvent.getApiClientId()).isEqualTo(TEST_API_CLIENT.getOauth2ClientId());
+        assertThat(metricsEvent.getApiClientOrgId()).isEqualTo(TEST_API_CLIENT.getOrganisation().getId());
+        assertThat(metricsEvent.getTrustedDirectory()).isEqualTo(TRUSTED_DIRECTORY_NAME);
+    }
+
+    private static void validateMetricsEventCoreFields(RouteMetricsEvent metricsEvent, long expectedTimestamp,
+            long expectedResponseTime, String expectedHttpMethod, String expectedRequestPath,
+            int expectedStatusCode, boolean isSuccessResponse, Map<String, Object> expectedMetricsContext) {
+
+        assertThat(metricsEvent.getRouteId()).isEqualTo(TEST_ROUTE_ID);
+        assertThat(metricsEvent.getEventType()).isEqualTo("route-metrics");
+        assertThat(metricsEvent.getHttpMethod()).isEqualTo(expectedHttpMethod);
+        assertThat(metricsEvent.getRequestPath()).isEqualTo(expectedRequestPath);
+        assertThat(metricsEvent.getContext()).isEqualTo(expectedMetricsContext);
+        assertThat(metricsEvent.getHttpStatusCode()).isEqualTo(expectedStatusCode);
+        assertThat(metricsEvent.isSuccessResponse()).isEqualTo(isSuccessResponse);
+        assertThat(metricsEvent.getTimestamp()).isEqualTo(expectedTimestamp);
+        assertThat(metricsEvent.getResponseTimeMillis()).isEqualTo(expectedResponseTime);
+    }
+
+    private RouteMetricsFilter createFilter(AtomicLong timestampSource) {
+        return new RouteMetricsFilter(ticker, timestampSource::getAndIncrement,
+                                      routeMetricsEventPublisher,
+                                      MetricsContextSupplier.EMPTY_CONTEXT_SUPPLIER);
+    }
+
+    private RouteMetricsFilter createFilter(AtomicLong timestampSource, MetricsContextSupplier metricsContextSupplier) {
+        return new RouteMetricsFilter(ticker, timestampSource::getAndIncrement,
+                routeMetricsEventPublisher,
+                metricsContextSupplier);
+    }
+
+
+
+    @Nested
+    public class HeapletTests {
+
+        @Test
+        void testHeapletCreatedRouteMetricsFilter() throws Exception {
+            final JsonValue config = json(object());
+            final HeapImpl heap = new HeapImpl(Name.of("heap"));
+            final RouteMetricsFilter routeMetricsFilter = (RouteMetricsFilter) new Heaplet().create(Name.of("test"), config, heap);
+            final Request request = new Request();
+            request.setUri("https://localhost/test/example");
+            request.setMethod("GET");
+
+            final TestSuccessResponseHandler handler = new TestSuccessResponseHandler();
+            final Promise<Response, NeverThrowsException> responsePromise = routeMetricsFilter.filter(createContext(), request, handler);
+            final Response response = responsePromise.getOrThrow(1, TimeUnit.SECONDS);
+
+            assertThat(handler.hasBeenInteractedWith()).isTrue();
+            assertThat(response.getStatus().isSuccessful()).isTrue();
+
+            // The heaplet produces a filter which uses a LoggerRouteMetricsEventPublisher, see log file for the output
+        }
+
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/TokenEndpointMetricsContextSupplierTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/TokenEndpointMetricsContextSupplierTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.metrics;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.forgerock.http.protocol.Form;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.metrics.TokenEndpointMetricsContextSupplier.Heaplet;
+
+
+class TokenEndpointMetricsContextSupplierTest {
+
+    // The Context is ignored by the supplier
+    private final Context httpRequestContext = new RootContext("test");
+
+    private TokenEndpointMetricsContextSupplier tokenEndpointMetricsContextSupplier;
+
+    @BeforeEach
+    void beforeEach() {
+        try {
+            tokenEndpointMetricsContextSupplier = (TokenEndpointMetricsContextSupplier) new Heaplet().create();
+        } catch (HeapException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void retrievesGrantTypeFromRequest() {
+        final String expectedGrantType = "client_credentials";
+
+        final Request request = new Request();
+        final Form form = new Form();
+        form.put("client_id", List.of("1232"));
+        form.put("something_else", List.of("blah", "blah"));
+        form.put("grant_type", List.of(expectedGrantType));
+        form.put("another_thing", List.of("ldfsfdsd"));
+        request.setEntity(form);
+
+        final Map<String, Object> metricsContext = tokenEndpointMetricsContextSupplier.getMetricsContext(httpRequestContext, request);
+        assertThat(metricsContext.size()).isEqualTo(1);
+        assertThat(metricsContext.get("grant_type")).isEqualTo(expectedGrantType);
+    }
+
+    @Test
+    void returnsEmptyContextWhenUnableToExtractGrantTypeFromRequest() {
+        assertThat(tokenEndpointMetricsContextSupplier.getMetricsContext(httpRequestContext, new Request())).isEmpty();
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
@@ -45,7 +45,7 @@ import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter.Heaplet;
 import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
 
-class FetchTrustedDirectoryFilterTest {
+public class FetchTrustedDirectoryFilterTest {
 
     private final String secureApiGatewayJwksUri = "https://test-bank.com";
     private TrustedDirectoryService trustedDirectoryService;
@@ -56,7 +56,7 @@ class FetchTrustedDirectoryFilterTest {
         trustedDirectoryService = new TrustedDirectoryServiceStatic(true, secureApiGatewayJwksUrl);
     }
 
-    private static ApiClient createApiClient(String issuer) {
+    public static ApiClient createApiClient(String issuer) {
         final JwtClaimsSet ssaClaims = new JwtClaimsSet();
         ssaClaims.setIssuer(issuer);
         final SignedJwt ssaSignedJwt = new SignedJwt(new JwsHeader(), ssaClaims, new byte[0], new byte[0]);


### PR DESCRIPTION
Spec:
https://wikis.forgerock.org/confluence/pages/viewpage.action?spaceKey=SBAT&title=SAPI-G+Endpoint+Metrics

Adding filter: RouteMetricsFilter which is responsible for gathering and reporting metrics each time a route processes a request.

Installing the filter for the following routes:
- All RS OB routes
- The following AS routes
  - /register
  - /authorize
  - /access_token

Metrics are reported by publishing them to the log file, see LoggerRouteMetricsEventPublisher.
This has required changes to the logback config to create a custom appender for use by the publisher, this appender publishes a raw message with no additional formatting.

Example log:
```
{
    "timestamp": 1698157533193,
    "eventType": "route-metrics",
    "routeId": "04-ob-as-authorize",
    "requestPath": "/am/oauth2/realms/root/realms/alpha/authorize",
    "httpMethod": "POST",
    "responseTimeMillis": 258,
    "httpStatusCode": 302,
    "successResponse": true,
    "apiClientId": "910a246a-3778-442c-a525-2c21d8f5fd3c",
    "apiClientOrgId": "0015800001041REAAY",
    "trustedDirectory": "OpenBanking Ltd",
    "context": {}
}
```

Logging is done on a best effort basis. If a data point is missing then it will be logged as a null value. All data points should be available on the happy path. For error paths, the apiClient data may be missing if the client failed to authenticate.

To get the ApiClient data for all of the AS routes has required changes to filters in order to set the ApiClient into the attributes context, the FetchApiClientFilter is used for the RS routes but this does not work with the AS routes as it requires an access_token in the request entity which is not the case. Filters changed:
- CreateApiClient.groovy for /register
- TokenEndpointTransportCertValidationFilter for /access_token
- New filter: AuthorizeResponseFetchApiClientFilter for /authorize

The context field is optional in the metrics event, custom data is currently supplied only for the /access_token route which is used to identify the grant_type of the access_token requested. 

https://github.com/SecureApiGateway/SecureApiGateway/issues/1151