### PR TITLE
1162: store IDM orgName instead of orgId in api client org name

### DIFF
--- a/config/7.3.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -168,7 +168,8 @@ def buildApiClientIdmObject(oauth2ClientId, softwareStatement) {
           "apiClientOrg"  : ["_ref": "managed/" + routeArgObjApiClientOrg + "/" + softwareStatement.getOrgId()]
   ]
 
-  if (softwareStatement.hasJwksUri()){logger.debug("jwks is '{}'", apiClientIdmObj)
+  if (softwareStatement.hasJwksUri()){
+    logger.debug("jwks is '{}'", apiClientIdmObj)
     apiClientIdmObj.jwksUri = softwareStatement.getJwksUri()
   } else {
     apiClientIdmObj.jwks = softwareStatement.getJwksSet().toJsonValue()

--- a/config/7.3.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -169,7 +169,6 @@ def buildApiClientIdmObject(oauth2ClientId, softwareStatement) {
   ]
 
   if (softwareStatement.hasJwksUri()){
-    logger.debug("jwks is '{}'", apiClientIdmObj)
     apiClientIdmObj.jwksUri = softwareStatement.getJwksUri()
   } else {
     apiClientIdmObj.jwks = softwareStatement.getJwksSet().toJsonValue()

--- a/config/7.3.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/CreateApiClient.groovy
@@ -168,7 +168,7 @@ def buildApiClientIdmObject(oauth2ClientId, softwareStatement) {
           "apiClientOrg"  : ["_ref": "managed/" + routeArgObjApiClientOrg + "/" + softwareStatement.getOrgId()]
   ]
 
-  if (softwareStatement.hasJwksUri()){
+  if (softwareStatement.hasJwksUri()){logger.debug("jwks is '{}'", apiClientIdmObj)
     apiClientIdmObj.jwksUri = softwareStatement.getJwksUri()
   } else {
     apiClientIdmObj.jwks = softwareStatement.getJwksSet().toJsonValue()
@@ -179,8 +179,8 @@ def buildApiClientIdmObject(oauth2ClientId, softwareStatement) {
 }
 
 def buildApiClientOrganisationIdmObject(SoftwareStatement softwareStatement) {
-  def organisationName = softwareStatement.getOrgId()
   def organisationIdentifier = softwareStatement.getOrgId()
+  def organisationName = softwareStatement.getOrgName() != null ? softwareStatement.getOrgName() : organisationIdentifier
   return [
           "_id" : organisationIdentifier,
           "id"  : organisationIdentifier,

--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -149,7 +149,7 @@ switch (method.toUpperCase()) {
         }
 
         def apiClientOrgId = softwareStatement.getOrgId()
-        def apiClientOrgName = apiClientOrgId
+        def apiClientOrgName = softwareStatement.getOrgName() !=null ? softwareStatement.getOrgName() : apiClientOrgId
         logger.debug(SCRIPT_NAME + "Inbound details from SSA: apiClientOrgName: {} apiClientOrgCertId: {}",
                 apiClientOrgName,
                 apiClientOrgId

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
@@ -43,6 +43,7 @@ public class SoftwareStatement extends SapiJwt {
     // The jwks_uri of the trusted directory against which the Software Statement signature may be validated
     private final URL trustedDirectoryJwksUrl;
     private final String orgId;
+    private final String orgName;
     private final String softwareId;
     private final String clientName;
     private final boolean hasJwksUri;
@@ -59,6 +60,7 @@ public class SoftwareStatement extends SapiJwt {
     public SoftwareStatement(Builder builder) {
         super(builder);
         this.orgId = builder.orgId;
+        this.orgName = builder.orgName;
         this.softwareId = builder.softwareId;
         this.clientName = builder.clientName;
         this.hasJwksUri = builder.hasJwksUri;
@@ -89,6 +91,13 @@ public class SoftwareStatement extends SapiJwt {
      */
     public String getOrgId() {
         return orgId;
+    }
+
+    /**
+     * @return the name of the Organisation in the Trusted Directory that issued the software statement
+     */
+    public String getOrgName() {
+        return orgName;
     }
 
     /**
@@ -145,6 +154,7 @@ public class SoftwareStatement extends SapiJwt {
         private final TrustedDirectoryService trustedDirectoryService;
         private TrustedDirectory trustedDirectory;
         private String orgId;
+        private String orgName;
         private String softwareId;
         private String clientName;
         private boolean hasJwksUri;
@@ -196,6 +206,7 @@ public class SoftwareStatement extends SapiJwt {
                 this.jwkSet = getJwkSet(transactionId);
             }
             this.orgId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementOrgIdClaimName());
+            this.orgName = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementOrgNameClaimName());
             this.softwareId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementSoftwareIdClaimName());
             this.clientName = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementClientNameClaimName());
             this.trustedDirectoryJwksUrl = trustedDirectory.getDirectoryJwksUri();

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -80,6 +80,13 @@ public interface TrustedDirectory {
 
     /**
      *
+     * @return the name of the claim in the software statement that holds the organisation name
+     * to which the Software Statement belongs
+     */
+    String getSoftwareStatementOrgNameClaimName();
+
+    /**
+     *
      * @return the name of the claim in the software statement that holds a unique identifier for the software statement
      */
     String getSoftwareStatementSoftwareIdClaimName();

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -46,6 +46,11 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
      */
     final static String softwareStatementOrgIdClaimName = "org_id";
     /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds the
+     * organisation name
+     */
+    final static String softwareStatementOrgNameClaimName = "org_name";
+    /*
      * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
      * software statement
      */
@@ -93,6 +98,11 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     @Override
     public String getSoftwareStatementOrgIdClaimName() {
         return softwareStatementOrgIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementOrgNameClaimName() {
+        return softwareStatementOrgNameClaimName;
     }
 
     @Override

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -46,6 +46,11 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      */
     private final static String softwareStatementOrgIdClaimName = "org_id";
     /*
+     * The name of the claim in the Open Banking Test Directory issued software statement that holds the
+     * organisation name
+     */
+    final static String softwareStatementOrgNameClaimName = "org_name";
+    /*
      * The name of the claim in the Open Banking Test Directory issued software statement that holds a uid for the
      * software statement
      */
@@ -95,6 +100,11 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     @Override
     public String getSoftwareStatementOrgIdClaimName() {
         return softwareStatementOrgIdClaimName;
+    }
+
+    @Override
+    public String getSoftwareStatementOrgNameClaimName() {
+        return softwareStatementOrgNameClaimName;
     }
 
     @Override

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementBuilderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementBuilderTest.java
@@ -42,7 +42,8 @@ class SoftwareStatementBuilderTest {
     private final JwtDecoder jwtDecoder = new JwtDecoder();
 
     private static final String ISSUER = "SSA_Issuer";
-    private static final String ORG_ID = "Acme Inc.";
+    private static final String ORG_ID = "0015800001041RACME";
+    private static final String ORG_NAME = "Acme Inc.";
     private static final String SOFTWARE_ID ="1234567890";
     private static final String SOFTWARE_CLIENT_NAME = "Acme App";
     private static final String JWKS_URI = "https://jwks.com";
@@ -70,6 +71,7 @@ class SoftwareStatementBuilderTest {
         // Then
         assertThat(softwareStatement).isNotNull();
         assertThat(softwareStatement.getOrgId()).isEqualTo(ORG_ID);
+        assertThat(softwareStatement.getOrgName()).isEqualTo(ORG_NAME);
         assertThat(softwareStatement.getSoftwareId()).isEqualTo(SOFTWARE_ID);
         assertThat(softwareStatement.getClientName()).isEqualTo(SOFTWARE_CLIENT_NAME);
         assertThat(softwareStatement.hasJwksUri()).isTrue();
@@ -88,6 +90,7 @@ class SoftwareStatementBuilderTest {
         // Then
         assertThat(softwareStatement).isNotNull();
         assertThat(softwareStatement.getOrgId()).isEqualTo(ORG_ID);
+        assertThat(softwareStatement.getOrgName()).isEqualTo(ORG_NAME);
         assertThat(softwareStatement.getSoftwareId()).isEqualTo(SOFTWARE_ID);
         assertThat(softwareStatement.getClientName()).isEqualTo(SOFTWARE_CLIENT_NAME);
         assertThat(softwareStatement.hasJwksUri()).isFalse();

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementTestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementTestFactory.java
@@ -26,7 +26,8 @@ import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryTestFactory;
 
 public class SoftwareStatementTestFactory {
-    private static final String ORG_ID = "Acme Inc.";
+    private static final String ORG_ID = "0015800001041RACME";
+    private static final String ORG_NAME= "Acme Inc.";
     private static final String SOFTWARE_ID ="1234567890";
     private static final String SOFTWARE_CLIENT_NAME = "Acme App";
     private static final String JWKS_URI = "https://jwks.com";
@@ -44,6 +45,7 @@ public class SoftwareStatementTestFactory {
         Map<String, Object> claims = new HashMap<>();
         claims.put("iss", directory.getIssuer());
         claims.put(directory.getSoftwareStatementOrgIdClaimName(), ORG_ID);
+        claims.put(directory.getSoftwareStatementOrgNameClaimName(), ORG_NAME);
         claims.put(directory.getSoftwareStatementSoftwareIdClaimName(), SOFTWARE_ID);
         claims.put(directory.getSoftwareStatementJwksUriClaimName(), JWKS_URI);
         claims.put(directory.getSoftwareStatementRedirectUrisClaimName(), REDIRECT_URIS);
@@ -59,6 +61,7 @@ public class SoftwareStatementTestFactory {
         Map<String, Object> claims = new HashMap<>();
         claims.put("iss", directory.getIssuer());
         claims.put(directory.getSoftwareStatementOrgIdClaimName(), ORG_ID);
+        claims.put(directory.getSoftwareStatementOrgNameClaimName(), ORG_NAME);
         claims.put(directory.getSoftwareStatementSoftwareIdClaimName(), SOFTWARE_ID);
         claims.put(directory.getSoftwareStatementJwksClaimName(), JWKS_SET.getObject());
         claims.put(directory.getSoftwareStatementRedirectUrisClaimName(), REDIRECT_URIS);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTestTest.java
@@ -31,6 +31,7 @@ class TrustedDirectoryOpenBankingTestTest {
         assertThat(trustedDirectory.getSoftwareStatementJwksClaimName()).isNull();
         assertThat(trustedDirectory.getSoftwareStatementJwksUriClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareJwksUriClaimName);
         assertThat(trustedDirectory.getSoftwareStatementOrgIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementOrgIdClaimName);
+        assertThat(trustedDirectory.getSoftwareStatementOrgNameClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementOrgNameClaimName);
         assertThat(trustedDirectory.getSoftwareStatementSoftwareIdClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementSoftwareIdClaimName);
         assertThat(trustedDirectory.getSoftwareStatementClientNameClaimName()).isEqualTo(TrustedDirectoryOpenBankingTest.softwareStatementClientNameClaimName);
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -59,6 +59,7 @@ class TrustedDirectoryServiceStaticTest {
         assertThat(directoryConfig.softwareStatementHoldsJwksUri()).isEqualTo(false);
         assertThat(directoryConfig.getSoftwareStatementJwksUriClaimName()).isNull();
         assertThat(directoryConfig.getSoftwareStatementOrgIdClaimName()).isEqualTo("org_id");
+        assertThat(directoryConfig.getSoftwareStatementOrgNameClaimName()).isEqualTo("org_name");
         assertThat(directoryConfig.getSoftwareStatementSoftwareIdClaimName()).isEqualTo("software_id");
         assertThat(directoryConfig.getSoftwareStatementClientNameClaimName()).isEqualTo("software_client_name");
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTestFactory.java
@@ -65,6 +65,11 @@ public class TrustedDirectoryTestFactory {
         }
 
         @Override
+        public String getSoftwareStatementOrgNameClaimName() {
+            return "org_name";
+        }
+
+        @Override
         public String getSoftwareStatementSoftwareIdClaimName() {
             return "software_id";
         }
@@ -114,6 +119,11 @@ public class TrustedDirectoryTestFactory {
         @Override
         public String getSoftwareStatementOrgIdClaimName() {
             return "org_id";
+        }
+
+        @Override
+        public String getSoftwareStatementOrgNameClaimName() {
+            return "org_name";
         }
 
         @Override


### PR DESCRIPTION
Until now when a CDR is request, It was stored the `orgId` claim value from the Software Statement in the api client organisation name.
This is a fix to store the `org_name` claim value, retrieved from the Software Statement, in the api client organisation name instead of the `org_id` claim value.
- Added support to get the value from Software Statement `org_name` claim to be stored in IDM instead of orgId.
- Updated the trusted directories with a new property to retrieve and store the `org_name` claim value.
- Updated the current unit tests to cover the new `org_name` claim value retrieved from the Software Statement.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1162