### PR TITLE
1151: Cleanup IG rotue names to make metrics reports clearer

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
@@ -1,6 +1,6 @@
 {
   "comment": "Authorise access to token endpoint",
-  "name": "54 - Open Banking OAuth2 token endpoint",
+  "name": "05 - Open Banking OAuth2 token endpoint",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{identity.platform.fqdn}",
   "condition": "${find(request.uri.path, '^/am/oauth2/realms/root/realms/&{am.realm}/access_token')}",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/100-internal-repo.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/100-internal-repo.json
@@ -1,5 +1,5 @@
 {
-  "name": "60 - Internal Repo Route for Remote Consent Service",
+  "name": "100 - Internal Repo Route for Remote Consent Service",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{identity.platform.fqdn}",
   "condition": "${find(request.uri.path, '^/repo/')}",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/99-ob-as-passthrough.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/99-ob-as-passthrough.json
@@ -1,6 +1,6 @@
 {
   "comment": "Passthrough for any unprotected AM endpoints (such as the XUI)",
-  "name": "99 - OBIE AS General",
+  "name": "99 - OBIE AS pass-through",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{identity.platform.fqdn}",
   "condition": "${find(request.uri.path, '^/am')}",


### PR DESCRIPTION
The name of the route is used for the routeId in metrics events, renaming the following routes to make the metrics reports easier to understand:
- 54-ob-token-endpoint.json => 05-ob-as-token-endpoint.json , renaming to follow the same pattern as the authorize endpoint
- 60-internal-repo.json => 100-internal-repo.json , renaming due to clash with ob route 60-ob-file-payment-submission
- 99-ob-as.json => 99-ob-as-passthrough.json to make it clearer that requests are simply passed through to the AS.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1151