### PR TITLE
1151: Adding softwareId field to RouteMetricsEvent

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEvent.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEvent.java
@@ -63,6 +63,10 @@ public class RouteMetricsEvent {
      */
     private String apiClientOrgId;
     /**
+     * The id of the Software Statement that the ApiClient has used to register
+     */
+    private String softwareId;
+    /**
      * Name of the trustedDirectory that the ApiClient is registered with
      */
     private String trustedDirectory;
@@ -75,92 +79,100 @@ public class RouteMetricsEvent {
         return timestamp;
     }
 
-    public String getEventType() {
-        return eventType;
-    }
-
-    public String getRouteId() {
-        return routeId;
-    }
-
-    public String getRequestPath() {
-        return requestPath;
-    }
-
-    public String getHttpMethod() {
-        return httpMethod;
-    }
-
-    public long getResponseTimeMillis() {
-        return responseTimeMillis;
-    }
-
-    public int getHttpStatusCode() {
-        return httpStatusCode;
-    }
-
-    public boolean isSuccessResponse() {
-        return successResponse;
-    }
-
-    public String getApiClientId() {
-        return apiClientId;
-    }
-
-    public String getApiClientOrgId() {
-        return apiClientOrgId;
-    }
-
-    public String getTrustedDirectory() {
-        return trustedDirectory;
-    }
-
-    public Map<String, Object> getContext() {
-        return context;
-    }
-
     public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public String getEventType() {
+        return eventType;
     }
 
     public void setEventType(String eventType) {
         this.eventType = eventType;
     }
 
+    public String getRouteId() {
+        return routeId;
+    }
+
     public void setRouteId(String routeId) {
         this.routeId = routeId;
+    }
+
+    public String getRequestPath() {
+        return requestPath;
     }
 
     public void setRequestPath(String requestPath) {
         this.requestPath = requestPath;
     }
 
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
     public void setHttpMethod(String httpMethod) {
         this.httpMethod = httpMethod;
+    }
+
+    public long getResponseTimeMillis() {
+        return responseTimeMillis;
     }
 
     public void setResponseTimeMillis(long responseTimeMillis) {
         this.responseTimeMillis = responseTimeMillis;
     }
 
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
     public void setHttpStatusCode(int httpStatusCode) {
         this.httpStatusCode = httpStatusCode;
+    }
+
+    public boolean isSuccessResponse() {
+        return successResponse;
     }
 
     public void setSuccessResponse(boolean successResponse) {
         this.successResponse = successResponse;
     }
 
+    public String getApiClientId() {
+        return apiClientId;
+    }
+
     public void setApiClientId(String apiClientId) {
         this.apiClientId = apiClientId;
+    }
+
+    public String getApiClientOrgId() {
+        return apiClientOrgId;
     }
 
     public void setApiClientOrgId(String apiClientOrgId) {
         this.apiClientOrgId = apiClientOrgId;
     }
 
+    public String getSoftwareId() {
+        return softwareId;
+    }
+
+    public void setSoftwareId(String softwareId) {
+        this.softwareId = softwareId;
+    }
+
+    public String getTrustedDirectory() {
+        return trustedDirectory;
+    }
+
     public void setTrustedDirectory(String trustedDirectory) {
         this.trustedDirectory = trustedDirectory;
+    }
+
+    public Map<String, Object> getContext() {
+        return context;
     }
 
     public void setContext(Map<String, Object> context) {

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
@@ -113,6 +113,7 @@ public class RouteMetricsFilter implements Filter {
         metricEvent.setRequestPath(request.getUri().getPath());
         metricEvent.setApiClientId(getApiClientId(apiClient));
         metricEvent.setApiClientOrgId(getApiClientOrgId(apiClient));
+        metricEvent.setSoftwareId(getSoftwareId(apiClient));
         metricEvent.setTrustedDirectory(getTrustedDirectory(apiClient));
         metricEvent.setHttpStatusCode(response.getStatus().getCode());
         metricEvent.setSuccessResponse(isSuccessResponse(response.getStatus()));
@@ -160,6 +161,14 @@ public class RouteMetricsFilter implements Filter {
             } else {
                 return apiClient.getOrganisation().getId();
             }
+        }
+    }
+
+    static String getSoftwareId(ApiClient apiClient ) {
+        if (apiClient == null) {
+            return null;
+        } else {
+            return apiClient.getSoftwareClientId();
         }
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisherTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisherTest.java
@@ -54,6 +54,7 @@ class LoggerRouteMetricsEventPublisherTest {
         routeMetricsEvent.setHttpStatusCode(201);
         routeMetricsEvent.setApiClientId("api-client-1");
         routeMetricsEvent.setApiClientOrgId("api-client-org-1");
+        routeMetricsEvent.setSoftwareId("EFxdsfrt23423");
         routeMetricsEvent.setTimestamp(100000);
         routeMetricsEvent.setTrustedDirectory("OpenBankingUK");
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilterTest.java
@@ -311,6 +311,7 @@ class RouteMetricsFilterTest {
                 expectedRequestPath, expectedStatusCode, isSuccessResponse, expectedMetricsContext);
         assertThat(metricsEvent.getApiClientId()).isEqualTo(TEST_API_CLIENT.getOauth2ClientId());
         assertThat(metricsEvent.getApiClientOrgId()).isEqualTo(TEST_API_CLIENT.getOrganisation().getId());
+        assertThat(metricsEvent.getSoftwareId()).isEqualTo(TEST_API_CLIENT.getSoftwareClientId());
         assertThat(metricsEvent.getTrustedDirectory()).isEqualTo(TRUSTED_DIRECTORY_NAME);
     }
 


### PR DESCRIPTION
The softwareId is the id of the Software Statement that the ApiClient has used to register.

Multiple OAuth2.0 registrations (and thus ApiClients) can be registered using he same Software Statement, storing the softwareId allows us to filter metrics for all ApiClients registered with a particular Software Statement.

This can be useful if we want to exclude all data produced by our automated tests.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1151