### PR TITLE
1179: Setting software_statement correctly in DCR GET response

### DIFF
--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -272,8 +272,8 @@ switch (method.toUpperCase()) {
         return next.handle(context, request)
                 .thenOnResult(response -> {
                     var apiClient = attributes.apiClient
-                    if (apiClient && apiClient.ssa) {
-                        addSoftwareStatementToResponse(response, apiClient.ssa)
+                    if (apiClient && apiClient.softwareStatementAssertion) {
+                        addSoftwareStatementToResponse(response, apiClient.softwareStatementAssertion)
                     }
                 })
     default:
@@ -397,11 +397,11 @@ private void rewriteUriToAccessExistingAmRegistration() {
     request.uri.setRawQuery("client_id=" + apiClientId)
 }
 
-private void addSoftwareStatementToResponse(response, ssa) {
+private void addSoftwareStatementToResponse(response, softwareStatementAssertion) {
     if (response.status.isSuccessful()) {
         var registrationResponse = response.getEntity().getJson()
         if (!registrationResponse["software_statement"]) {
-            registrationResponse["software_statement"] = ssa
+            registrationResponse["software_statement"] = softwareStatementAssertion.build()
         }
         response.entity.setJson(registrationResponse)
     }


### PR DESCRIPTION
A bug was introduced in PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk/pull/449

As part of refactoring in this PR to make the ApiClient available for the RouteMetricsFilters, a bug was introduced in the DCR GET response. The software_statement field was missing due to the ApiClient in the attributes context having different fields names to the previous implementation.

Fixing ProcessRegistration to call the correct methods on ApiClient to obtain the software_statement.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1179