### PR TITLE
1189: Allow OAuth2.0 token_endpoint_auth_methods to be configured via environment variable

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -4,7 +4,9 @@
       "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|true}"}
     },
     "oauth2": {
-      "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]
+      "tokenEndpointAuthMethodsSupported": {
+        "$list": "&{ig.oauth2.token.endpoint.auth.methods|private_key_jwt,tls_client_auth}"
+      }
     },
     "urls": {
       "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -4,7 +4,9 @@
       "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|false}"}
     },
     "oauth2": {
-      "tokenEndpointAuthMethodsSupported": ["private_key_jwt", "tls_client_auth"]
+      "tokenEndpointAuthMethodsSupported": {
+        "$list": "&{ig.oauth2.token.endpoint.auth.methods|private_key_jwt,tls_client_auth}"
+      }
     },
     "urls": {
       "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",


### PR DESCRIPTION
Adding support for new environment variable: `IG_OAUTH2_TOKEN_ENDPOINT_AUTH_METHODS`
This is expected to be a comma separated list of strings containing the OAuth2.0 token_endpoint_auth_methods supported by this deployment.

Defaulting to: `private_key_jwt,tls_client_auth`

https://github.com/SecureApiGateway/SecureApiGateway/issues/1189