### PR TITLE
1205: Improving AuthorizeResponseFetchApiClientFilter to return a properly formatted OAuth 2.0 error when client_id param is missing

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/rest/HttpHeaderNames.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/rest/HttpHeaderNames.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.common.rest;
+
+/**
+ * Util class containing commonly used HTTP header names
+ */
+public class HttpHeaderNames {
+
+    /**
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept">Accept</a> header
+     */
+    public static final String ACCEPT = "Accept";
+
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import com.forgerock.sapi.gateway.common.error.OAuthErrorResponseFactory;
 import com.forgerock.sapi.gateway.common.rest.ContentTypeFormatterFactory;
+import com.forgerock.sapi.gateway.common.rest.HttpHeaderNames;
 
 /**
  * Base class for validating that authorize requests are FAPI compliant.
@@ -53,7 +54,6 @@ public abstract class BaseFapiAuthorizeRequestValidationFilter implements Filter
     private static final Set<String> VALID_HTTP_REQUEST_METHODS = Set.of("POST", "GET");
     private static final List<String> REQUIRED_REQUEST_JWT_CLAIMS = List.of("scope", "nonce", "response_type", "redirect_uri", "client_id");
     protected static final String STATE_PARAM_NAME = "state";
-    private static final String ACCEPT_HEADER_NAME = "accept";
     private static final String REQUEST_JWT_PARAM_NAME = "request";
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -68,7 +68,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilter implements Filter
             return Promises.newResultPromise(new Response(Status.METHOD_NOT_ALLOWED));
         }
 
-        final Header acceptHeader = request.getHeaders().get(ACCEPT_HEADER_NAME);
+        final Header acceptHeader = request.getHeaders().get(HttpHeaderNames.ACCEPT);
         return getRequestJwtClaimSet(request).thenAsync(requestJwtClaimSet -> {
             if (requestJwtClaimSet == null) {
                 final String errorDescription = "Request must have a 'request' parameter the value of which must be a signed jwt";


### PR DESCRIPTION
Using the OAuthErrorResponseFactory to create an invalid_request error when the client_id param is missing from requests processed by AuthorizeResponseFetchApiClientFilter.

HTTP 400 Bad Request is now returned with the following error message:
```
{
    "error": "invalid_request",
    "error_description": "'client_id' is missing in the request."
}
```

https://github.com/SecureApiGateway/SecureApiGateway/issues/1205