### PR TITLE
1211: Fixing response_type validation for DCR and Authorize requests

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilter.java
@@ -337,12 +337,14 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
     }
 
     /**
-     * https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server
-     * Part 2 specifies:
+     * Validates that the response_types field contains only FAPI compliant response_type values, namely
+     * "code" or "code id_token".
+     * <p>
+     * https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server specifies:
      * the authorization server shall require
      *
      *    1. the response_type value code id_token, or
-     *    2.  the response_type value code in conjunction with the response_mode value jwt;
+     *    2. the response_type value code in conjunction with the response_mode value jwt
      * @param registrationObject
      */
     void validateResponseTypes(JsonValue registrationObject) {
@@ -352,7 +354,8 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
         }
 
         for (String responseTypes : responseTypesList) {
-            final HashSet<String> responseTypesSet = new HashSet<>(Arrays.asList(responseTypes.split(" ")));
+            // Convert the request responseTypes String into a set by splitting on whitespace
+            final Set<String> responseTypesSet = Set.of(responseTypes.split(" "));
             if (!responseTypesSet.equals(RESPONSE_TYPE_CODE) && !responseTypesSet.equals(RESPONSE_TYPE_CODE_ID_TOKEN)) {
                 throw new ValidationException(DCRErrorCode.INVALID_CLIENT_METADATA,
                         "Invalid response_types value: " + responseTypes + ", must be one of: \"code\" or \"code id_token\"");

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FAPIAdvancedDCRValidationFilterTest.java
@@ -289,48 +289,22 @@ class FAPIAdvancedDCRValidationFilterTest {
         }
 
         @Test
+        void responseTypesFieldValid() {
+            List<List<String>> validResponseTypeValues = List.of(List.of("code"),
+                                                                 List.of("code id_token"),
+                                                                 List.of("id_token code"),
+                                                                 List.of("code", "code id_token"),
+                                                                 List.of("id_token code", "code"));
+
+            for (List<String> validResponseTypeValue : validResponseTypeValues) {
+                fapiValidationFilter.validateResponseTypes(json(object(field("response_types", array(validResponseTypeValue.toArray())))));
+            }
+        }
+
+        @Test
         void responseTypesInvalid() {
             runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, json(object(field("response_types", array("blah")))),
-                    DCRErrorCode.INVALID_CLIENT_METADATA, "response_types not supported, must be one of: [[code], [code id_token]]");
-        }
-
-        @Test
-        void responseTypesCodeValid() {
-            fapiValidationFilter.validateResponseTypes(json(object(field("response_types", array("code")), field("response_mode", "jwt"))));
-        }
-
-        @Test
-        void responseTypesCodeMissingResponseMode() {
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, json(object(field("response_types", array("code")))),
-                    DCRErrorCode.INVALID_CLIENT_METADATA, "request object must contain field: response_mode when response_types is: [code]");
-        }
-
-        @Test
-        void responseTypesCodeInvalidResponseMode() {
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, json(object(field("response_types", array("code")),
-                            field("response_mode", "blah"))),
-                    DCRErrorCode.INVALID_CLIENT_METADATA, "response_mode not supported, must be one of: [jwt]");
-        }
-
-        @Test
-        void responseTypesCodeIdTokenValid() {
-            fapiValidationFilter.validateResponseTypes(json(object(field("response_types", array("code id_token")),
-                    field("scope", "blah openid something"))));
-        }
-
-        @Test
-        void responseTypesCodeIdTokenMissingScopeField() {
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes,
-                    json(object(field("response_types", array("code id_token")))),
-                    DCRErrorCode.INVALID_CLIENT_METADATA, "request must contain field: scope");
-        }
-
-        @Test
-        void responseTypesCodeIdTokenNotRequestingOpenIdScope() {
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes,
-                    json(object(field("response_types", array("code id_token")), field("scope", "accounts payments"))),
-                    DCRErrorCode.INVALID_CLIENT_METADATA,
-                    "request object must include openid as one of the requested scopes when response_types is: [code id_token]");
+                    DCRErrorCode.INVALID_CLIENT_METADATA, "Invalid response_types value: blah, must be one of: \"code\" or \"code id_token\"");
         }
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilterTest.java
@@ -224,8 +224,8 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "redirect_uri", "https://test-tpp.com/redirect",
                 "nonce", "sdffdsdfdssfd",
                 "state", state,
-                "scope", "payments",
-                "response_type", "jwt"));
+                "scope", "openid payments",
+                "response_type", "code id_token"));
         final String signedRequestJwt = createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
@@ -240,8 +240,8 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
         final JWTClaimsSet requestClaims = JWTClaimsSet.parse(Map.of("client_id", "client-123",
                 "redirect_uri", "https://test-tpp.com/redirect",
                 "nonce", "sdffdsdfdssfd",
-                "scope", "payments",
-                "response_type", "jwt"));
+                "scope", "openid payments",
+                "response_type", "code id_token"));
         final String signedRequestJwt = createSignedRequestJwt(requestClaims);
 
         // state param in URI but NOT in jwt claims
@@ -251,6 +251,25 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
         validateSuccessResponse(responsePromise);
         // Verify that state param was removed from the request that was sent onwards
         validateHandlerReceivedRequestWithoutStateParam();
+    }
+
+    @Test
+    void succeedsForValidRequestUsingJarm() throws Exception {
+        final String state = UUID.randomUUID().toString();
+        final JWTClaimsSet requestClaims = JWTClaimsSet.parse(Map.of("client_id", "client-123",
+                "redirect_uri", "https://test-tpp.com/redirect",
+                "nonce", "sdffdsdfdssfd",
+                "state", state,
+                "scope", "openid payments",
+                "response_type", "code",
+                "response_mode", "jwt"));
+        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+
+        final Request request = createRequest(signedRequestJwt, state);
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
+        validateSuccessResponse(responsePromise);
+        validateHandlerReceivedRequestWithStateParam(state);
     }
 
     protected abstract Request createRequest(String requestJwt, String state) throws Exception;


### PR DESCRIPTION
- DCR filter validates at FAPI compliant response_types are being registered ("code", "code id_token" or both)
  - Logic to validate response_mode has been moved to the authorize filter as it is only specified in authorize requests
- Authorize checks that the chosen response_type for that particular call is being used in a FAPI compliant fashion
  - For JARM the response_type = "code" then response_mode is validated to check that it is "jwt"
  - For non-JARM the response_tyoe = "code id_token", the scope requested is validated to check that it includes "openid"
- Fixing bug in ProcessRegistration script preventing DCR registering multiple response_types

https://github.com/SecureApiGateway/SecureApiGateway/issues/1211