### PR TITLE
987: Changes for migration to Artifact Registry

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -69,24 +69,24 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
       # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: docker build
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
 
-      - name: 'run functional tests'
+      - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
           args: '-v SERVICE_NAME=${{ env.SERVICE_NAME }}'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,7 +30,7 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - name: Get version
+      - name: Get Version
         id: get_version
         run: |
           echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
@@ -39,12 +39,12 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
-      - name: Context forgerock maven community repository
+      - name: Context Forgerock Maven Community Repository
         if: contains( env.VERSION, 'SNAPSHOT')
         run: |
           echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
 
-      - name: Build maven
+      - name: Build Maven
         run: |
           mvn clean install
         env:
@@ -53,7 +53,7 @@ jobs:
 
       # Override maven settings
       - uses: actions/setup-java@v3
-        name: set java and maven cache with protected repository
+        name: Set Java and Maven Cache with Community Repository
         with:
           distribution: 'adopt'
           java-version: '17'
@@ -63,7 +63,7 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - name: Deploy artifact package
+      - name: Deploy Artifact Package
         run: mvn -B deploy -DskipTests -Ddockerfile.skip
         env:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
@@ -82,7 +82,7 @@ jobs:
         run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
 
-      - name: docker build
+      - name: Docker Build
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
           docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Java version and maven settings with protected repository id
       - uses: actions/setup-java@v3
-        name: set java and maven cache with protected repository
+        name: Set Java and Maven Cache with Protected Repository
         with:
           distribution: 'adopt'
           java-version: '17'
@@ -69,7 +69,8 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
@@ -77,7 +78,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1.1.1
 
       # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
+      - name: Auth Docker
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: docker build
@@ -85,7 +87,12 @@ jobs:
           make docker tag=${{ env.GIT_SHA_SHORT }}
           docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
           docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
-
+  
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    needs: build
+    steps:
       - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,16 +31,16 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username to authentication protected repo
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable encrypted password to authentication protected repo
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build maven
         run: |
@@ -62,7 +62,7 @@ jobs:
       
       - run: echo "GITHUB_USER set to ${{ env.GITHUB_USER }}"
       
-      - name: 'build environment and run functional tests'
+      - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
           args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=${{ env.SERVICE_NAME }} -v ENVIRONMENT=${{ env.GITHUB_USER }}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,16 +12,16 @@ env:
   SERVICE_NAME: ig
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     name: Check PR integrity
     steps:
       - uses: actions/checkout@v3
 
       # set java and cache
-      - uses: actions/setup-java@v3
+      - name: Set Java and Maven Cache
+        uses: actions/setup-java@v3
         id: set_java_maven
-        name: set java and maven cache
         with:
           distribution: 'adopt'
           java-version: '17'
@@ -31,7 +31,21 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username to authentication protected repo
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable encrypted password to authentication protected repo
 
-      - uses: google-github-actions/auth@v2
+      - name: Build maven
+        run: |
+          mvn clean install
+        env:
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+  
+  build:
+    runs-on: ubuntu-latest
+    name: Build Docker Image
+    needs: check
+    steps:
+
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
@@ -39,15 +53,9 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
-          gcloud auth configure-docker europe-west4-docker.pkg.dev
-
-      - name: Build maven
+      - name: Auth Docker
         run: |
-          mvn clean install
-        env:
-          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Docker Image
         run: |
@@ -56,12 +64,16 @@ jobs:
           # Create production mode docker image
           make docker tag="$PR_NUMBER-prod"
 
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    needs: build
+    steps:
+
       - name: Create lowercase Github Username
         id: toLowerCase
         run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
-      
-      - run: echo "GITHUB_USER set to ${{ env.GITHUB_USER }}"
-      
+            
       - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,9 @@ jobs:
     name: Build Docker Image
     needs: check
     steps:
-
+      
+      - uses: actions/checkout@v3
+      
       - name: Auth to GCP  
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/release-publish-java-and-docker.yml
+++ b/.github/workflows/release-publish-java-and-docker.yml
@@ -81,19 +81,19 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         id: gcloud_auth
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         id: gcloud_sdk
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
       - name: Set up docker auth
         id: gcloud_docker_auth
         run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: prepare context
         id: prepare_context
@@ -104,6 +104,6 @@ jobs:
         id: build_docker
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GCR_RELEASE_REPO }}
-          docker tag eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:latest
-          docker tag eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ inputs.release_version_number }}
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}
+          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:latest
+          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ inputs.release_version_number }}
+          docker push ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }} --all-tags

--- a/.github/workflows/release-publish-java-and-docker.yml
+++ b/.github/workflows/release-publish-java-and-docker.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build Docker Image
         id: build_docker
         run: |
-          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GCR_RELEASE_REPO }}
+          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ vars.GAR_RELEASE_REPO }}
           docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:latest
           docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ inputs.release_version_number }}
           docker push ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }} --all-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
       FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
       GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
-      GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
+      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_draft_and_pr:
     name: Call publish draft and PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     secrets:
       FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
       FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
+      GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
       GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
 
   release_draft_and_pr:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-repo := sbat-gcr-develop
-service := "gate/ig"
+repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
+service := "ig"
 
 docker: conf
 ifndef tag
 	$(warning no tag supplied; latest assumed)
 	$(eval tag=latest)
 endif
-	docker build docker/7.3.0/ig/ -t eu.gcr.io/${repo}/securebanking/${service}:${tag}
-	docker push eu.gcr.io/${repo}/securebanking/${service}:${tag}
+	docker build docker/7.3.0/ig/ -t ${repo}/securebanking/${service}:${tag}
+	docker push ${repo}/securebanking/${service}:${tag}
 
 conf:
 ifndef env


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202