### PR TITLE
1215: Fixing AuthorizeResponseFetchApiClientFilter alias to reference the Heaplet correctly

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/04-ob-as-authorize.json
@@ -38,8 +38,8 @@
           "comment": "Ensure authorize request object is FAPI compliant"
         },
         {
-          "name": "AuthoriseResponseFetchApiClientFilter",
-          "type": "AuthoriseResponseFetchApiClientFilter",
+          "name": "AuthorizeResponseFetchApiClientFilter",
+          "type": "AuthorizeResponseFetchApiClientFilter",
           "comment": "Add ApiClient data to the context attributes",
           "config": {
             "idmGetApiClientBaseUri": "https://&{identity.platform.fqdn}/openidm/managed/apiClient",

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -23,7 +23,7 @@ import org.forgerock.openig.alias.ClassAliasResolver;
 import com.forgerock.sapi.gateway.am.ReSignIdTokenFilter;
 import com.forgerock.sapi.gateway.common.exception.SapiLogAttachedExceptionFilterHeaplet;
 import com.forgerock.sapi.gateway.consent.ConsentRequestAccessAuthorisationFilter;
-import com.forgerock.sapi.gateway.dcr.idm.AuthorizeResponseFetchApiClientFilter;
+import com.forgerock.sapi.gateway.dcr.idm.AuthorizeResponseFetchApiClientFilterHeaplet;
 import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.idm.ParResponseFetchApiClientFilterHeaplet;
 import com.forgerock.sapi.gateway.dcr.request.RegistrationRequestEntityValidatorFilter;
@@ -72,7 +72,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("ContextCertificateRetriever", ContextCertificateRetriever.class);
         ALIASES.put("HeaderCertificateRetriever", HeaderCertificateRetriever.class);
         ALIASES.put("RouteMetricsFilter", RouteMetricsFilter.class);
-        ALIASES.put("AuthoriseResponseFetchApiClientFilter", AuthorizeResponseFetchApiClientFilter.class);
+        ALIASES.put("AuthorizeResponseFetchApiClientFilter", AuthorizeResponseFetchApiClientFilterHeaplet.class);
         ALIASES.put("TokenEndpointMetricsContextSupplier", TokenEndpointMetricsContextSupplier.class);
         ALIASES.put("FapiAuthorizeRequestValidationFilter", FapiAuthorizeRequestValidationFilter.class);
         ALIASES.put("FapiParRequestValidationFilter", FapiParRequestValidationFilter.class);

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilterHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilterHeaplet.java
@@ -41,7 +41,7 @@ import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter.BaseFetchApiClien
  * }
  * }</pre>
  */
-public class AuthoriseResponseFetchApiClientFilterHeaplet extends BaseFetchApiClientHeaplet {
+public class AuthorizeResponseFetchApiClientFilterHeaplet extends BaseFetchApiClientHeaplet {
 
     @Override
     public Object create() throws HeapException {

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/idm/AuthorizeResponseFetchApiClientFilterTest.java
@@ -64,7 +64,7 @@ class AuthorizeResponseFetchApiClientFilterTest extends BaseAuthorizeResponseFet
     public class HeapletTests {
         @Test
         void failsToConstructIfClientHandlerIsMissing() {
-            final HeapException heapException = assertThrows(HeapException.class, () -> new AuthoriseResponseFetchApiClientFilterHeaplet().create(Name.of("test"),
+            final HeapException heapException = assertThrows(HeapException.class, () -> new AuthorizeResponseFetchApiClientFilterHeaplet().create(Name.of("test"),
                     json(object()), new HeapImpl(Name.of("heap"))), "Invalid object declaration");
             assertEquals(heapException.getCause().getMessage(), "/clientHandler: Expecting a value");
         }
@@ -75,7 +75,7 @@ class AuthorizeResponseFetchApiClientFilterTest extends BaseAuthorizeResponseFet
             final HeapImpl heap = new HeapImpl(Name.of("heap"));
             heap.put("idmClientHandler", idmClientHandler);
 
-            assertThrows(JsonValueException.class, () -> new AuthoriseResponseFetchApiClientFilterHeaplet().create(Name.of("test"),
+            assertThrows(JsonValueException.class, () -> new AuthorizeResponseFetchApiClientFilterHeaplet().create(Name.of("test"),
                     json(object(field("clientHandler", "idmClientHandler"))), heap), "/idmGetApiClientBaseUri: Expecting a value");
         }
 
@@ -89,7 +89,7 @@ class AuthorizeResponseFetchApiClientFilterTest extends BaseAuthorizeResponseFet
 
             final JsonValue config = json(object(field("clientHandler", "idmClientHandler"),
                     field("idmGetApiClientBaseUri", idmBaseUri)));
-            final AuthorizeResponseFetchApiClientFilter filter = (AuthorizeResponseFetchApiClientFilter) new AuthoriseResponseFetchApiClientFilterHeaplet().create(Name.of("test"), config, heap);
+            final AuthorizeResponseFetchApiClientFilter filter = (AuthorizeResponseFetchApiClientFilter) new AuthorizeResponseFetchApiClientFilterHeaplet().create(Name.of("test"), config, heap);
 
             // Test the filter created by the Heaplet
             callFilterValidateSuccessBehaviour(idmApiClientData, filter);


### PR DESCRIPTION
The route protecting /authorize was failing to load due to a bug introduced by the PR https://github.com/SecureApiGateway/secure-api-gateway-ob-uk/pull/467 which extracted the AuthorizeResponseFetchApiClientFilterHeaplet class.

Fixing the issue by updating the SecureApiGatewayClassAliasResolver to reference the new class.

Correcting a typo in the filter name alias renaming Authorise => Authorize to match the OAuth2.0 terminology.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1215