### PR TITLE
1217: Merge check and build step together

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ env:
   SERVICE_NAME: ig
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
     name: Check PR integrity
     steps:
@@ -37,15 +37,7 @@ jobs:
         env:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-  
-  build:
-    runs-on: ubuntu-latest
-    name: Build Docker Image
-    needs: check
-    steps:
-      
-      - uses: actions/checkout@v3
-      
+        
       - name: Auth to GCP  
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
The build jars during build maven step will now be included in the build docker image as they were being left out

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1217