### PR TITLE
1222: Adding support for all jwt response_mode values in validation logic

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/am/AuthorizeResponseJwtReSignFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/am/AuthorizeResponseJwtReSignFilter.java
@@ -39,6 +39,7 @@ import org.forgerock.openig.heap.HeapException;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.AsyncFunction;
 import org.forgerock.util.Reject;
+import org.forgerock.util.annotations.VisibleForTesting;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
 import org.slf4j.Logger;
@@ -212,14 +213,15 @@ public class AuthorizeResponseJwtReSignFilter implements Filter {
      * @param request the {@link Request} to inspect
      * @return true if the response_mode is set to jwt or false if it is not specified or has another value.
      */
-    private boolean isJwtResponseMode(Request request) {
+    @VisibleForTesting
+    boolean isJwtResponseMode(Request request) {
         final String requestJwtString = request.getQueryParams().getFirst("request");
         if (requestJwtString == null) {
             return false;
         }
         final SignedJwt requestJwt = jwtReconstruction.reconstructJwt(requestJwtString, SignedJwt.class);
         final String responseMode = requestJwt.getClaimsSet().getClaim("response_mode", String.class);
-        return "jwt".equals(responseMode);
+        return responseMode != null && responseMode.contains("jwt");
     }
 
     private static boolean isFragmentResponse(MutableUri locationUri) {

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
@@ -145,7 +145,8 @@ public abstract class BaseFapiAuthorizeRequestValidationFilter implements Filter
             return errorResponseFactory.invalidRequestErrorResponse(acceptHeader,
                     "response_mode must be specified when response_type is: \"code\"");
         }
-        if (!"jwt".equals(responseMode)) {
+        // Check if response_mode is one of: jwt, query.jwt, fragment.jwt or form_post.jwt
+        if (!responseMode.contains("jwt")) {
             return errorResponseFactory.invalidRequestErrorResponse(acceptHeader,"response_mode must be: \"jwt\" when response_type is: \"code\"");
         }
         return null;

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilterTest.java
@@ -37,6 +37,8 @@ import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.forgerock.sapi.gateway.common.rest.HttpMediaTypes;
 import com.forgerock.sapi.gateway.util.CryptoUtils;
@@ -253,8 +255,9 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
         validateHandlerReceivedRequestWithoutStateParam();
     }
 
-    @Test
-    void succeedsForValidRequestUsingJarm() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"jwt", "query.jwt", "fragment.jwt", "form_post.jwt"})
+    void succeedsForValidRequestUsingJarm(String jwtResponseMode) throws Exception {
         final String state = UUID.randomUUID().toString();
         final JWTClaimsSet requestClaims = JWTClaimsSet.parse(Map.of("client_id", "client-123",
                 "redirect_uri", "https://test-tpp.com/redirect",
@@ -262,7 +265,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "openid payments",
                 "response_type", "code",
-                "response_mode", "jwt"));
+                "response_mode", jwtResponseMode));
         final String signedRequestJwt = createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);


### PR DESCRIPTION
Supporting all JARM response_mode values: "jwt", "query.jwt", "fragment.jwt", "form_post.jwt" in validation logic.

BaseFapiAuthorizeRequestValidationFilter now validates that one of the JARM response_mode values is specified when response_type is code (rather than only allowing response_mode="jwt").

AuthorizeResponseJwtReSignFilter handles JARM JWT re-signing in a similar fashion.

A separate issue has been raised to review how we handle form_post / form_post.jwt re-signing, as it is not currently supported by our system (the AM response with the invalidly signed JWTs will be passed through). See: https://github.com/SecureApiGateway/SecureApiGateway/issues/1233

https://github.com/SecureApiGateway/SecureApiGateway/issues/1222