### PR TITLE
987: Artifact Registry Migration

### DIFF
--- a/.github/workflows/release-publish-java-and-docker.yml
+++ b/.github/workflows/release-publish-java-and-docker.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: google-github-actions/auth@v2
         id: gcloud_auth
         with:
-          credentials_json: ${{ secrets.DEV_GAR_KEY }}
+          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
 
       - name: Set up Cloud SDK
         id: gcloud_sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
       FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
       GCR_CREDENTIALS_JSON: ${{ secrets.DEV_GAR_KEY }}
-      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
+      GAR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_draft_and_pr:
     name: Call publish draft and PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     secrets:
       FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
       FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-      GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
+      GCR_CREDENTIALS_JSON: ${{ secrets.DEV_GAR_KEY }}
       GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_draft_and_pr:


### PR DESCRIPTION
Issue with workflows calling another workflow and secrets, seems that 'called' workflows cannot access the secrets, so the values have to be passed from the 'calling' workflow

When changing to artifact registry some of these values were changed causing errors 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/987