### PR TITLE
987: Try passing GAR var as variable instead of secret

### DIFF
--- a/.github/workflows/release-publish-java-and-docker.yml
+++ b/.github/workflows/release-publish-java-and-docker.yml
@@ -16,15 +16,16 @@ on:
       SERVICE_NAME:
         required: false
         type: string
-        default: 'gate/ig'
+        default: 'ig'
+      GAR_RELEASE_REPO:
+        type: string
+        required: true
     secrets:
       FR_ARTIFACTORY_USER:
         required: true
       FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
         required: true
       GCR_CREDENTIALS_JSON:
-        required: true
-      GAR_RELEASE_REPO:
         required: true
 
 jobs:
@@ -103,7 +104,7 @@ jobs:
       - name: Build Docker Image
         id: build_docker
         run: |
-          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ secrets.GAR_RELEASE_REPO }}
-          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:latest
-          docker tag ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ inputs.release_version_number }}
-          docker push ${{ secrets.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }} --all-tags
+          make docker tag=${{ env.GIT_SHA_SHORT }} repo=${{ inputs.GAR_RELEASE_REPO }}
+          docker tag ${{ inputs.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ inputs.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:latest
+          docker tag ${{ inputs.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ inputs.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }}:${{ inputs.release_version_number }}
+          docker push ${{ inputs.GAR_RELEASE_REPO }}/securebanking/${{ inputs.SERVICE_NAME }} --all-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,11 @@ jobs:
     with:
       release_version_number: ${{ inputs.release_version_number }}
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
+      GAR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
     secrets:
       FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
       FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
       GCR_CREDENTIALS_JSON: ${{ secrets.DEV_GAR_KEY }}
-      GAR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_draft_and_pr:
     name: Call publish draft and PR

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
-service := "ig"
+service := ig
 
 docker: conf
 ifndef tag


### PR DESCRIPTION
I _think_ the issue is that we are passing a var as a secret and something is getting lost in translation, the GAR (Google artifact registry) is a variable in the organisation as it doesn't need to be kept secret, so changed the workflows to use it as a var(input) instead of a secret as we do when building PRs

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/987