### PR TITLE
1273: Adding x-fapi-interaction-id to RouteMetricsEvent

### DIFF
--- a/config/7.3.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/FapiTransactionIdFilter.groovy
@@ -20,6 +20,10 @@ if (fapiInteractionId != null) {
     logger.debug(SCRIPT_NAME + "Found x-fapi-interaction-id: " + fapiInteractionId + " setting as TransactionId")
     TransactionIdContext newContext = new TransactionIdContext(context, new TransactionId(fapiInteractionId))
 
+    // Add the x-fapi-interaction-id to the attributes context so that it can be retrieved by filters that are
+    // installed before this one and require the id on the response path (these filters cannot see the TransactionIdContext)
+    attributes.put(FAPI_INTERACTION_ID, fapiInteractionId)
+
     // Add the x-fapi-interaction-id to the MDC context for logging purposes, ensure the previously set value is restored
     final String previousMdcFapiInteractionId = MDC.get(FAPI_INTERACTION_ID)
     MDC.put(FAPI_INTERACTION_ID, fapiInteractionId)

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/FAPIUtils.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/FAPIUtils.java
@@ -15,10 +15,32 @@
  */
 package com.forgerock.sapi.gateway.fapi;
 
+import java.util.Optional;
+
+import org.forgerock.services.context.AttributesContext;
 import org.forgerock.services.context.Context;
 import org.forgerock.services.context.TransactionIdContext;
 
 public class FAPIUtils {
+
+    public static final String X_FAPI_INTERACTION_ID = "x-fapi-interaction-id";
+
+    /**
+     * Retrieves the x-fapi-interaction-id value from the {@link org.forgerock.services.context.AttributesContext}
+     *
+     * @param context Context object to extract the id from
+     * @return Optional containing the x-fapi-interaction-id String or is empty.
+     */
+    public static Optional<String> getFapiInteractionId(Context context) {
+        if (context != null && context.containsContext(AttributesContext.class)) {
+            final AttributesContext attributesContext = context.asContext(AttributesContext.class);
+            final Object interactionId = attributesContext.getAttributes().get(X_FAPI_INTERACTION_ID);
+            if (interactionId instanceof String) {
+                return Optional.of((String) interactionId);
+            }
+        }
+        return Optional.empty();
+    }
 
     /**
      * Function which returns the x-fapi-interaction-id from the Context or returns a string to display should one
@@ -29,7 +51,10 @@ public class FAPIUtils {
      *
      * @param context Context to extract the value from
      * @return String the x-fapi-interaction-id or "No x-fapi-interaction-id"
+     * @deprecated The intended use of this methods is for when we wish to log the  x-fapi-interaction-id,
+     * the value is now set in the {@link org.slf4j.MDC} and is automatically added to all logs.
      */
+    @Deprecated
     public static String getFapiInteractionIdForDisplay(Context context) {
         if (context != null && context.containsContext(TransactionIdContext.class)) {
             return context.asContext(TransactionIdContext.class).getTransactionId().getValue();

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEvent.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsEvent.java
@@ -74,6 +74,10 @@ public class RouteMetricsEvent {
      * Custom contextual information which may be supplied on a per-request basis
      */
     private Map<String, Object> context;
+    /**
+     * x-fapi-interaction-id header value for the request, this enables the request to be traced through the platform.
+     */
+    private String fapiInteractionId;
 
     public long getTimestamp() {
         return timestamp;
@@ -177,5 +181,13 @@ public class RouteMetricsEvent {
 
     public void setContext(Map<String, Object> context) {
         this.context = context;
+    }
+
+    public String getFapiInteractionId() {
+        return fapiInteractionId;
+    }
+
+    public void setFapiInteractionId(String fapiInteractionId) {
+        this.fapiInteractionId = fapiInteractionId;
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import com.forgerock.sapi.gateway.dcr.idm.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.fapi.FAPIUtils;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
@@ -117,6 +118,8 @@ public class RouteMetricsFilter implements Filter {
         metricEvent.setTrustedDirectory(getTrustedDirectory(apiClient));
         metricEvent.setHttpStatusCode(response.getStatus().getCode());
         metricEvent.setSuccessResponse(isSuccessResponse(response.getStatus()));
+
+        FAPIUtils.getFapiInteractionId(context).ifPresent(metricEvent::setFapiInteractionId);
 
         stopwatch.stop();
         metricEvent.setResponseTimeMillis(stopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisherTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/metrics/LoggerRouteMetricsEventPublisherTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +58,7 @@ class LoggerRouteMetricsEventPublisherTest {
         routeMetricsEvent.setSoftwareId("EFxdsfrt23423");
         routeMetricsEvent.setTimestamp(100000);
         routeMetricsEvent.setTrustedDirectory("OpenBankingUK");
+        routeMetricsEvent.setFapiInteractionId(UUID.randomUUID().toString());
 
         ArgumentCaptor<String> jsonArgumentCapture = ArgumentCaptor.forClass(String.class);
         doNothing().when(logger).info(anyString(), jsonArgumentCapture.capture());


### PR DESCRIPTION
New field RouteMetricsEvent.fapiInteractionId has been added, which is set to the value of the x-fapi-interaction-id header.

This allows requests to be traced through the system based on metrics event data. This can be useful for investigating errors or high request latencies.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1273