### PR TITLE
1276: Docker Tag not happening in IG

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Docker Build
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
+          
+      - name: Docker tag
+        run: |
           docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
           docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
   

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -85,10 +85,7 @@ jobs:
       - name: Docker Build
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          
-      - name: Docker tag
-        run: |
-          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/gate/${{ env.SERVICE_NAME }}:latest
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
           docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
   
   test:


### PR DESCRIPTION
'gate' was still a part of the repo name in the tagging which is no longer required

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1276