### PR TITLE
1227: Fixing merge and release github actions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,18 +44,6 @@ jobs:
         run: |
           echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
 
-      # Override maven settings
-      - uses: actions/setup-java@v4
-        name: Set Java and Maven Cache with Community Repository
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-          architecture: x64
-          cache: 'maven'
-          server-id: ${{ env.MAVEN_SERVER_COMMUNITY }} # community repo to publish the java artifact
-          server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
-          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
-
       - name: Auth to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -77,6 +65,18 @@ jobs:
         env:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+
+      # Overwrite maven settings with the creds for the maven server to deploy to
+      - uses: actions/setup-java@v4
+        name: Set Java and Maven Cache with Community Repository
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          architecture: x64
+          cache: 'maven'
+          server-id: ${{ env.MAVEN_SERVER_COMMUNITY }} # community repo to publish the java artifact
+          server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
+          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
       - name: Deploy Maven Artifact Package
         run: mvn -B deploy -DskipTests -Ddockerfile.skip

--- a/.github/workflows/release-publish-java-and-docker.yml
+++ b/.github/workflows/release-publish-java-and-docker.yml
@@ -53,19 +53,6 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      # Override maven settings
-      - uses: actions/setup-java@v4
-        id: override_maven_settings
-        name: set java and maven cache with protected repository
-        with:
-          distribution: 'zulu'
-          java-version: ${{ inputs.java_version }}
-          architecture: x64
-          cache: 'maven'
-          server-id: maven.forgerock.org-community # community repo to publish the java artifact
-          server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
-          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
-
       - uses: google-github-actions/auth@v2
         id: gcloud_auth
         with:
@@ -94,6 +81,18 @@ jobs:
         env:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+
+      # Overwrite maven settings with the creds for the maven server to deploy to
+      - uses: actions/setup-java@v4
+        name: Set Java and Maven Cache with Community Repository
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          architecture: x64
+          cache: 'maven'
+          server-id: ${{ env.MAVEN_SERVER_COMMUNITY }} # community repo to publish the java artifact
+          server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
+          server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
       # Deploy the java artifact
       - name: Deploy release


### PR DESCRIPTION
actions/setup-java step needs to be run multiple times to set up the artifactory server to pull from and push to (as they differ). Fixing ordering of steps so that the community server is setup in the step prior to deploying our artifact.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1227