### PR TITLE
1318: No longer overwrite jwks_uri in as well-known

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/02-ob-as-metadata.json
@@ -20,8 +20,7 @@
               "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
               "mtlsEndpoints": ["registration_endpoint", "token_endpoint"],
               "igHost": "&{ig.fqdn}",
-              "mtlsHost": "&{mtls.fqdn}",
-              "jwksUri": "https://&{hosts.obJwks}/&{ob.aspsp.org.id}/&{ob.aspsp.software.id}.jwks"
+              "mtlsHost": "&{mtls.fqdn}"
             }
           }
         },


### PR DESCRIPTION
The OIDC well-known response contains a jwks_uri entry specifying where the public certs for the TLS and signing certs used by the API provider can be found. We no longer need to override this as it is now configured in AM, in the OAuth2Provider's OIDC Advanced config.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1318