### PR TITLE
1318: Remove ability to override jwks_uri

### DIFF
--- a/config/7.3.0/securebanking/ig/scripts/groovy/ASWellKnownFilter.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ASWellKnownFilter.groovy
@@ -10,11 +10,6 @@ next.handle(context, request).thenOnResult(response -> {
         // Configure auth methods supported using filter arg: tokenEndpointAuthMethodsSupported
         wellKnownData["token_endpoint_auth_methods_supported"] = tokenEndpointAuthMethodsSupported
 
-        // Configure jwks_uri if arg is present
-        if (jwksUri) {
-            wellKnownData["jwks_uri"] = jwksUri
-        }
-
         // Update endpoints defined in mtlsEndpoints arg to use the mtls host
         mtlsEndpoints.each { endpoint ->
             wellKnownData[endpoint] = wellKnownData[endpoint].replace(igHost, mtlsHost)


### PR DESCRIPTION
For now we can remove code relating to jwks_uri, although for non OB ecosystems it might be necessary to support this agian if it becomes difficult to add this to the AM config

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1318