### PR TITLE
1159: Upgrade IG to version 2024.3.0 

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
           architecture: x64
           cache: 'maven'
-          server-id: forgerock-private-releases # protected repo id to get the protected dependencies
+          server-id: forgerock-internal-releases # protected repo id to get the protected dependencies
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: '17'
           architecture: x64
           cache: 'maven'
-          server-id: forgerock-private-releases # protected release repo
+          server-id: forgerock-internal-releases # protected release repo
           server-username: FR_ARTIFACTORY_USER # env variable for username to authentication protected repo
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable encrypted password to authentication protected repo
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -60,7 +60,7 @@ jobs:
           java-version: ${{ inputs.java_version }}
           architecture: x64
           cache: 'maven'
-          server-id: forgerock-private-releases # protected repo id to get the protected dependencies
+          server-id: forgerock-internal-releases # protected repo id to get the protected dependencies
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 

--- a/.github/workflows/release-publish-java-and-docker.yml
+++ b/.github/workflows/release-publish-java-and-docker.yml
@@ -49,7 +49,7 @@ jobs:
           java-version: ${{ inputs.java_version }}
           architecture: x64
           cache: 'maven'
-          server-id: forgerock-private-releases # protected repo id to get the protected dependencies
+          server-id: forgerock-internal-releases # protected repo id to get the protected dependencies
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ to the samples.
 |-------------------------|----------------------------------|
 | IG_FQDN                 | Ig host name                     |
 | IDENTITY_PLATFORM_FQDN  | Identity platform host name      |
-| ENVIRONMENT_TYPE        | CDK / CDM / FIDC *(1)            |
+| CLOUD_TYPE        | CDK / CDM / FIDC *(1)            |
 | RS_FQDN                 | RS host name                     |                 
 | RCS_FQDN                | RCS host name                    |               
 | RCS_UI_FQDN             | RCS UI host name                 |             
@@ -203,7 +203,7 @@ to the samples.
 | CA_KEYSTORE_KEYPASS     | CA key store key password        |
 
 **References**
-- *(1) `ENVIRONMENT_TYPE`:
+- *(1) `CLOUD_TYPE`:
   - CDK value: (Cloud Developer's Kit) development identity platform
   - CDM value: CDM (Cloud Deployment Model) identity cloud platform
   - FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ to the samples.
 |-------------------------|----------------------------------|
 | IG_FQDN                 | Ig host name                     |
 | IDENTITY_PLATFORM_FQDN  | Identity platform host name      |
-| CLOUD_TYPE        | CDK / CDM / FIDC *(1)            |
+| ENVIRONMENT_TYPE        | CDK / CDM / FIDC *(1)            |
 | RS_FQDN                 | RS host name                     |                 
 | RCS_FQDN                | RCS host name                    |               
 | RCS_UI_FQDN             | RCS UI host name                 |             
@@ -203,7 +203,7 @@ to the samples.
 | CA_KEYSTORE_KEYPASS     | CA key store key password        |
 
 **References**
-- *(1) `CLOUD_TYPE`:
+- *(1) `ENVIRONMENT_TYPE`:
   - CDK value: (Cloud Developer's Kit) development identity platform
   - CDM value: CDM (Cloud Deployment Model) identity cloud platform
   - FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform

--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -245,8 +245,8 @@
             "config": {
               "file": "&{ig.instance.dir}&{ig.ob.aspsp.signing.keystore.path}",
               "storeType": "&{ig.ob.aspsp.signing.keystore.type}",
-              "storePassword": "ig.ob.aspsp.signing.keystore.storepass",
-              "keyEntryPassword": "ig.ob.aspsp.signing.keystore.keypass",
+              "storePasswordSecretId": "ig.ob.aspsp.signing.keystore.storepass",
+              "entryPasswordSecretId": "ig.ob.aspsp.signing.keystore.keypass",
               "secretsProvider": "SystemAndEnvSecretStore-IAM",
               "mappings": [{
                 "secretId": "jwt.signer",

--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -390,23 +390,6 @@
       }
     },
     {
-      "name": "OBReverseProxyHandler",
-      "comment": "ReverseProxyHandler for calls to OB Directory services",
-      "type": "ReverseProxyHandler",
-      "capture": [
-        "request",
-        "response"
-      ],
-      "config": {
-        "tls": {
-          "type": "ClientTlsOptions",
-          "config": {
-            "trustManager": "TrustManager-OB"
-          }
-        }
-      }
-    },
-    {
       "name": "OBJwkSetService",
       "type": "CaffeineCachingJwkSetService",
       "config": {

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -233,8 +233,8 @@
             "config": {
               "file": "&{ig.instance.dir}&{ig.ob.aspsp.signing.keystore.path}",
               "storeType": "&{ig.ob.aspsp.signing.keystore.type}",
-              "storePassword": "ig.ob.aspsp.signing.keystore.storepass",
-              "keyEntryPassword": "ig.ob.aspsp.signing.keystore.keypass",
+              "storePasswordSecretId": "ig.ob.aspsp.signing.keystore.storepass",
+              "entryPasswordSecretId": "ig.ob.aspsp.signing.keystore.keypass",
               "secretsProvider": "SystemAndEnvSecretStore-IAM",
               "mappings": [{
                 "secretId": "jwt.signer",

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -378,23 +378,6 @@
       }
     },
     {
-      "name": "OBReverseProxyHandler",
-      "comment": "ReverseProxyHandler for calls to OB Directory services",
-      "type": "ReverseProxyHandler",
-      "capture": [
-        "request",
-        "response"
-      ],
-      "config": {
-        "tls": {
-          "type": "ClientTlsOptions",
-          "config": {
-            "trustManager": "TrustManager-OB"
-          }
-        }
-      }
-    },
-    {
       "name": "OBJwkSetService",
       "type": "CaffeineCachingJwkSetService",
       "config": {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/72-ob-jwkms-apiclient-getssa.json
@@ -10,8 +10,8 @@
       "config": {
         "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
         "storeType": "PKCS12",
-        "storePassword": "ig.test.directory.signing.keystore.storepass",
-        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
+        "storePasswordSecretId": "ig.test.directory.signing.keystore.storepass",
+        "entryPasswordSecretId": "ig.test.directory.signing.keystore.storepass",
         "secretsProvider": "SystemAndEnvSecretStore-IAM",
         "mappings": [{
           "secretId": "jwt.signer",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/76-ob-jwkms-test-directory-jwks.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/76-ob-jwkms-test-directory-jwks.json
@@ -10,8 +10,8 @@
       "config": {
         "file": "&{ig.instance.dir}&{ig.test.directory.signing.keystore.path}",
         "storeType": "PKCS12",
-        "storePassword": "ig.test.directory.signing.keystore.storepass",
-        "keyEntryPassword": "ig.test.directory.signing.keystore.storepass",
+        "storePasswordSecretId": "ig.test.directory.signing.keystore.storepass",
+        "entryPasswordSecretId": "ig.test.directory.signing.keystore.storepass",
         "secretsProvider": "SystemAndEnvSecretStore-IAM",
         "mappings": [{
           "secretId": "jwt.signer",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
@@ -28,6 +28,25 @@
           }
         },
         {
+          "name": "RemoveRequestHeaders",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "ssl-client-verify",
+              "X-Forwarded-For",
+              "X-Forwarded-Host",
+              "X-Forwarded-Port",
+              "X-Forwarded-Proto",
+              "X-Forwarded-Scheme",
+              "X-Real-IP",
+              "X-Request-ID",
+              "X-Scheme",
+              "Host"
+            ]
+          }
+        },
+        {
           "name": "ReplaceEncodingFilter",
           "type": "HeaderFilter",
           "config": {
@@ -43,7 +62,7 @@
           }
         }
       ],
-      "handler": "OBReverseProxyHandler"
+      "handler": "OBClientHandler"
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
             </snapshots>
         </repository>
         <repository>
-            <id>forgerock-private-releases</id>
+            <id>forgerock-internal-releases</id>
             <name>ForgeRock Private Releases Repository</name>
-            <url>https://maven.forgerock.org/artifactory/private-releases</url>
+            <url>https://maven.forgerock.org/artifactory/internal-releases</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         </repository>
         <repository>
             <id>forgerock-internal-releases</id>
-            <name>ForgeRock Private Releases Repository</name>
+            <name>ForgeRock Internal Releases Repository</name>
             <url>https://maven.forgerock.org/artifactory/internal-releases</url>
             <snapshots>
                 <enabled>false</enabled>

--- a/secure-api-gateway-ob-uk-docker/Dockerfile
+++ b/secure-api-gateway-ob-uk-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2023.4.0
+FROM gcr.io/forgerock-io/ig:pit1:2024.3.0-M2024-02.3
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into

--- a/secure-api-gateway-ob-uk-docker/Dockerfile
+++ b/secure-api-gateway-ob-uk-docker/Dockerfile
@@ -31,4 +31,3 @@ RUN test -f /opt/ig/lib/secure-api-gateway-ig-extensions-*.jar
 
 COPY --chown=forgerock:root 7.3.0/ig/config /var/ig/config/
 COPY --chown=forgerock:root 7.3.0/ig/scripts /var/ig/scripts/
-

--- a/secure-api-gateway-ob-uk-docker/Dockerfile
+++ b/secure-api-gateway-ob-uk-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:pit1:2024.3.0-M2024-02.3
+FROM gcr.io/forgerock-io/ig/pit1:2024.3.0-RC3
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into

--- a/secure-api-gateway-ob-uk-docker/Dockerfile
+++ b/secure-api-gateway-ob-uk-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig/pit1:2024.3.0-RC3
+FROM gcr.io/forgerock-io/ig:2024.3.0
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
Upgrading IG to version 2024.3.0 (latest release).

See related core PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/13

Minor change required to fix the JWKS proxy route used to call the OB directory JWKS endpoint. We now use the OBClientHandler and strip off all the request headers prior to calling the endpoint, this resolves an issue where OB directory infrastructure is failing to handle our request.

Updating KeyStoreSecretStore config to fix deprecation warnings.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1159