### PR TITLE
Revert "1345: Removing jwksproxy route (#529)"

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -12,6 +12,9 @@
       "idmManagedObjectsBaseUri": "https://&{identity.platform.fqdn}/openidm/managed",
       "rsBaseUri": "http://&{rs.internal.svc}:8080"
     },
+    "hosts": {
+      "obJwks": "&{ig.ob.jwks.host|keystore.openbankingtest.org.uk}"
+    },
     "vertxConfig": {
       "maxHeaderSize": 16384,
       "initialSettings": {

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -12,6 +12,9 @@
       "idmManagedObjectsBaseUri": "https://&{identity.platform.fqdn}/openidm/managed",
       "rsBaseUri": "http://&{rs.internal.svc}:8080"
     },
+    "hosts": {
+      "obJwks": "&{ig.ob.jwks.host|keystore.openbankingtest.org.uk}"
+    },
     "vertxConfig": {
       "maxHeaderSize": 16384,
       "initialSettings": {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -74,6 +74,10 @@
             "type": "application/x-groovy",
             "file": "ProcessRegistration.groovy",
             "args": {
+              "routeArgObJwksHosts": [
+                "&{hosts.obJwks}"
+              ],
+              "routeArgProxyBaseUrl": "https://&{ig.fqdn}/jwkms/jwksproxy",
               "jwkSetService": "${heap['OBJwkSetService']}",
               "allowIgIssuedTestCerts": "${security.enableTestTrustedDirectory}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/80-jwks-proxy.json
@@ -1,0 +1,68 @@
+{
+  "comment": "JWK set proxy - provides publicly trusted route to Open Banking JWK publishing points protected with non-public SSL certs",
+  "name": "80 - Open Banking JWKS Proxy",
+  "auditService": "AuditService-OB-Route",
+  "condition": "${find(request.uri.path, '^/jwkms/jwksproxy')}",
+  "handler": {
+    "type": "Chain",
+    "config": {
+      "filters": [
+        "SBATFapiInteractionFilterChain",
+        {
+          "name": "JWKSProxyProcessRequest",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "JWKSProxyProcessRequest.groovy",
+            "args": {
+              "routeArgObJwksHosts": [
+                "&{hosts.obJwks}"
+              ]
+            }
+          }
+        },
+        {
+          "type": "ForwardedRequestFilter",
+          "config": {
+            "host": "${split(request.uri.path, '/')[1]}"
+          }
+        },
+        {
+          "name": "RemoveRequestHeaders",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "REQUEST",
+            "remove": [
+              "ssl-client-verify",
+              "X-Forwarded-For",
+              "X-Forwarded-Host",
+              "X-Forwarded-Port",
+              "X-Forwarded-Proto",
+              "X-Forwarded-Scheme",
+              "X-Real-IP",
+              "X-Request-ID",
+              "X-Scheme",
+              "Host"
+            ]
+          }
+        },
+        {
+          "name": "ReplaceEncodingFilter",
+          "type": "HeaderFilter",
+          "config": {
+            "messageType": "RESPONSE",
+            "remove": [
+              "Content-Type"
+            ],
+            "add": {
+              "Content-Type": [
+                "application/json"
+              ]
+            }
+          }
+        }
+      ],
+      "handler": "OBClientHandler"
+    }
+  }
+}

--- a/config/7.3.0/securebanking/ig/scripts/groovy/JWKSProxyProcessRequest.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/JWKSProxyProcessRequest.groovy
@@ -1,0 +1,40 @@
+// e.g. https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks ->
+//        https://obdemo.nightly.forgerock.financial/jwkms/jwksproxy/keystore.openbankingtest.org.uk/keystore/openbanking.jwks
+
+def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
+if(fapiInteractionId == null) fapiInteractionId = "No x-fapi-interaction-id";
+SCRIPT_NAME = "[JWKSProxyProcessRequest] (" + fapiInteractionId + ") - ";
+
+logger.debug(SCRIPT_NAME + "Running...")
+
+def errorResponse(httpCode, message) {
+  logger.error(SCRIPT_NAME + "Returning error " + httpCode + ": " + message);
+  def response = new Response(httpCode);
+  response.headers['Content-Type'] = "application/json";
+  response.entity = "{ \"error\":\"" + message + "\"}";
+  return response;
+}
+
+def splitPath = request.uri.path.split("/");
+
+if (splitPath.length < 4) {
+  return(errorResponse(Status.BAD_REQUEST,"Badly formatted proxy URL"));
+}
+
+def targetHost = splitPath[3];
+
+if (!routeArgObJwksHosts) {
+  return(errorResponse(Status.INTERNAL_SERVER_ERROR,"No authorised jwks hosts configured"));
+}
+
+if (!routeArgObJwksHosts.asList().contains(targetHost)) {
+  return(errorResponse(Status.FORBIDDEN,"Host " + targetHost + " not permitted"));
+}
+
+def newPath = "https://" + Arrays.copyOfRange(splitPath, 3, splitPath.length).join("/");
+
+logger.debug(SCRIPT_NAME + "Setting path to {}", newPath);
+
+request.setUri(newPath);
+
+next.handle(context, request);

--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -189,6 +189,25 @@ switch (method.toUpperCase()) {
         // Verify that the tls transport cert is registered for the TPP's software statement
         if ( softwareStatement.hasJwksUri() ) {
             URL softwareStatementJwksUri = softwareStatement.getJwksUri();
+            // We need to set the jwks_uri claim in the registration request because the software statement might not
+            // have the jwks URI in the jwks_uri claim in the software statement. For example, the OB Test Directory
+            // issued SSAs have thw jwks URI claim in the software_jwks_endpoint claim - which is unknown to AM and
+            // will be ignored. This will result in an OAuth2 Client with an empty Json Web Key URI field. This will
+            // Result AM being unable to validate client credential jws used in `private_key_jwt` as the
+            // `token_endpoint_auth_method`.
+            if (routeArgObJwksHosts) {
+                // If the JWKS URI host is in our list of private JWKS hosts, then proxy back through IG
+                if (routeArgObJwksHosts && routeArgObJwksHosts.contains(softwareStatementJwksUri.getHost())) {
+                    String newUri = routeArgProxyBaseUrl + "/" + softwareStatementJwksUri.getHost() + softwareStatementJwksUri.getPath();
+                    logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}", softwareStatementJwksUri, newUri);
+                    try {
+                        softwareStatementJwksUri = new URL(newUri);
+                    } catch (MalformedURLException e){
+                        logger.error(SCRIPT_NAME + "Failed to create URL from new URI string {}", newUri);
+                        return new Response(Status.INTERNAL_SERVER_ERROR);
+                    }
+                }
+            }
             regRequestClaimsSet.setClaim("jwks_uri", softwareStatementJwksUri.toString());
 
             // AM doesn't understand JWS encoded registration requests, so we need to convert the jwt JSON and pass it on


### PR DESCRIPTION
This reverts commit 6da338bedf0b7c2773eca25c12ed39f3ba7213fc.

The jwksproxy route is needed for backward compatibility, existing OB deployments will have OAuth2.0 clients registered in AM with their jwks_uri configured via the proxy. Therefore, removing the route would break these existing clients.

The jwksproxy will be retained for OB deployments but will not be present in SAPI-G core.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1345