### PR TITLE
1358: Support configrable clock skew when validating iat

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -8,6 +8,9 @@
         "$list": "&{ig.oauth2.token.endpoint.auth.methods|private_key_jwt,tls_client_auth}"
       }
     },
+    "jwtValidation": {
+      "clockSkewAllowanceDuration": "5s"
+    },
     "urls": {
       "idmManagedObjectsBaseUri": "https://&{identity.platform.fqdn}/openidm/managed",
       "rsBaseUri": "http://&{rs.internal.svc}:8080"

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -8,6 +8,9 @@
         "$list": "&{ig.oauth2.token.endpoint.auth.methods|private_key_jwt,tls_client_auth}"
       }
     },
+    "jwtValidation": {
+      "clockSkewAllowanceDuration": "5s"
+    },
     "urls": {
       "idmManagedObjectsBaseUri": "https://&{identity.platform.fqdn}/openidm/managed",
       "rsBaseUri": "http://&{rs.internal.svc}:8080"

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -114,7 +114,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -113,7 +113,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -137,7 +137,8 @@
             "file": "ProcessDetachedSig.groovy",
             "args": {
               "routeArgHeaderName": "x-jws-signature",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "routeArgClockSkewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -29,7 +29,8 @@
             "verificationSecretId": "any.value.in.regex.format",
             "secretsProvider": "SecretsProvider-AmJWK",
             "issuer": "https://&{ig.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-            "audience": "&{rcs.consent.response.jwt.issuer}"
+            "audience": "&{rcs.consent.response.jwt.issuer}",
+            "skewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
           }
         },
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
@@ -38,7 +38,8 @@
             "verificationSecretId": "any.value.in.regex.format",
             "secretsProvider": "SecretsProvider-AmJWK",
             "issuer": "https://&{ig.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-            "audience": "&{rcs.consent.response.jwt.issuer}"
+            "audience": "&{rcs.consent.response.jwt.issuer}",
+            "skewAllowance": "&{jwtValidation.clockSkewAllowanceDuration}"
           }
         },
         {

--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -295,8 +295,8 @@ def validateCriticalParameters(JWSHeader jwsHeader) {
     def skewedIatTimestamp = iatTimestamp.minus(clockSkewAllowance)
     def currentTimestamp = Instant.now()
     if (skewedIatTimestamp.isAfter(currentTimestamp)) {
-        logger.error(SCRIPT_NAME + "Could not validate detached JWT - claim: " + IAT_CRIT_CLAIM + " value: " + iatTimestamp.getEpochSecond()
-                + ", current time: " + currentTimestamp.getEpochSecond() + ", skewAllowance: " + clockSkewAllowance)
+        logger.error(SCRIPT_NAME + "Could not validate detached JWT - claim: " + IAT_CRIT_CLAIM + " must be in the past, value: " + iatTimestamp.getEpochSecond()
+                + ", current time: " + currentTimestamp.getEpochSecond() + ", clockSkewAllowance: " + clockSkewAllowance)
         return false
     }
     logger.debug(SCRIPT_NAME + "Found valid iat!")


### PR DESCRIPTION
New config: jwtValidation.clockSkewAllowanceDuration (type [duration](https://backstage.forgerock.com/docs/ig/2024.3/reference/preface.html#definition-duration)) can be used to control the allowed clock skew, currently set as 5s

Configuring IdTokenValidationFilter's skewAllowance (used in RCS routes) to allow for a clock skew.

Updated ProcessDetachedSig.groovy to validate http://openbanking.org.uk/iat using the clock skew allowance supplied from config.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1358