### PR TITLE
1387: Renaming FetchApiClientResourcesChain to ValidateApiClientMtlsCertChain

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -109,9 +109,9 @@
       "capture" : [ "response", "request" ]
     },
     {
-      "name": "FetchApiClientResourcesChain",
+      "name": "ValidateApiClientMtlsCertChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the apiClient, apiClientJwkSet and trustedDirectory attributes in the context based on the client_id of the access_token",
+      "comment": "This filter chain validates the ApiClient's MTLS cert using the Trusted Directory, it first fetches all of the resources it needs to perform the validation",
       "config" : {
         "filters": [
           {

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -97,9 +97,9 @@
       "capture" : [ "response", "request" ]
     },
     {
-      "name": "FetchApiClientResourcesChain",
+      "name": "ValidateApiClientMtlsCertChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the apiClient, apiClientJwkSet and trustedDirectory attributes in the context based on the client_id of the access_token",
+      "comment": "This filter chain validates the ApiClient's MTLS cert using the Trusted Directory, it first fetches all of the resources it needs to perform the validation",
       "config" : {
         "filters": [
           {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -64,7 +64,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Make sure client certificate includes AISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -89,7 +89,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesAISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -89,7 +89,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesAISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
@@ -65,7 +65,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -84,7 +84,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -80,7 +80,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -84,7 +84,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -84,7 +84,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -79,7 +79,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -84,7 +84,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -85,7 +85,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -61,7 +61,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includes CBPII role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
@@ -89,7 +89,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includes CBPII role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/68-ob-aggregated-polling.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/68-ob-aggregated-polling.json
@@ -99,7 +99,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "The access token required for accessing the API must have at last one scope of 'allowedScopes'",
           "name": "Token Scopes Verifier",


### PR DESCRIPTION
The MTLS validation is the main purpose of the chain, the resources are fetched in order to carry this out.

The new name makes validation being carried out more obvious when the chain name is read in a route definition.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1387