### PR TITLE
1395: access token must not require openid scope

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -60,8 +60,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -65,8 +65,7 @@
           "type": "OAuth2ResourceServerFilter",
           "config": {
             "scopes": [
-              "payments",
-              "openid"
+              "payments"
             ],
             "requireHttps": false,
             "realm": "OpenIG",


### PR DESCRIPTION
Where an endpoint only requires an access token obtained using a client_credentials grant, that access token should not require the openid scope

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1395