### PR TITLE
1393: Updating ProcessRegistration to be compatible with core URI changes

### DIFF
--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessRegistration.groovy
@@ -188,7 +188,7 @@ switch (method.toUpperCase()) {
 
         // Verify that the tls transport cert is registered for the TPP's software statement
         if ( softwareStatement.hasJwksUri() ) {
-            URL softwareStatementJwksUri = softwareStatement.getJwksUri();
+            URI softwareStatementJwksUri = softwareStatement.getJwksUri();
             // We need to set the jwks_uri claim in the registration request because the software statement might not
             // have the jwks URI in the jwks_uri claim in the software statement. For example, the OB Test Directory
             // issued SSAs have thw jwks URI claim in the software_jwks_endpoint claim - which is unknown to AM and
@@ -201,9 +201,9 @@ switch (method.toUpperCase()) {
                     String newUri = routeArgProxyBaseUrl + "/" + softwareStatementJwksUri.getHost() + softwareStatementJwksUri.getPath();
                     logger.debug(SCRIPT_NAME + "Updating private JWKS URI from {} to {}", softwareStatementJwksUri, newUri);
                     try {
-                        softwareStatementJwksUri = new URL(newUri);
-                    } catch (MalformedURLException e){
-                        logger.error(SCRIPT_NAME + "Failed to create URL from new URI string {}", newUri);
+                        softwareStatementJwksUri = new URI(newUri);
+                    } catch (URISyntaxException e){
+                        logger.error(SCRIPT_NAME + "Failed to create proxy URI for: {}", newUri);
                         return new Response(Status.INTERNAL_SERVER_ERROR);
                     }
                 }
@@ -219,7 +219,7 @@ switch (method.toUpperCase()) {
             logger.debug(SCRIPT_NAME + "Checking cert against remote jwks: " + softwareStatementJwksUri)
             return jwkSetService.getJwkSet(softwareStatementJwksUri)
                     .thenCatchAsync(e -> {
-                        String errorDescription = "Unable to get jwks from url: " + softwareStatementJwksUri
+                        String errorDescription = "Unable to get jwks from uri: " + softwareStatementJwksUri
                         logger.warn(SCRIPT_NAME + "Failed to get jwks due to exception: " + errorDescription, e)
                         return newResultPromise(errorResponseFactory.invalidClientMetadataErrorResponse(errorDescription))
                     })
@@ -290,13 +290,12 @@ switch (method.toUpperCase()) {
  * https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html
  */
 private void validateRegistrationRedirectUris(RegistrationRequest registrationRequest) {
-    List<URL> regRedirectUris = registrationRequest.getRedirectUris()
+    List<URI> regRedirectUris = registrationRequest.getRedirectUris()
     SoftwareStatement softwareStatement = registrationRequest.getSoftwareStatement()
-    List<URL> ssaRedirectUris = softwareStatement.getRedirectUris()
+    List<URI> ssaRedirectUris = softwareStatement.getRedirectUris()
 
-    for(URL regRequestRedirectUri : regRedirectUris){
-        if(!"https".equals(regRequestRedirectUri.getProtocol())){
-
+    for(URI regRequestRedirectUri : regRedirectUris){
+        if(!"https".equals(regRequestRedirectUri.getScheme())){
             throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must use https")
         }
 


### PR DESCRIPTION
softwareStatement.getJwksUri() has been changed to return a URI, updating ProcessRegistration.groovy to work with a URI.

Related core PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/31

https://github.com/SecureApiGateway/SecureApiGateway/issues/1393