### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,5 +11,5 @@ jobs:
     uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-merge.yml@main
     secrets: inherit
     with:
-      componentName: secure-api-gateway-ob
+      componentName: secure-api-gateway-ob-uk
       dockerTag: $(echo ${{ github.sha }} | cut -c1-7)


### PR DESCRIPTION
Correct componentName to be pushed to ci repo

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389