### PR TITLE
1305: Fix route config

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
@@ -74,8 +74,8 @@
         },
         {
           "comment": "Verify that the client's transport cert is valid and is mapped to their SSA",
-          "name": "ResponsePathTransportCertValidationFilter",
-          "type": "ResponsePathTransportCertValidationFilter",
+          "name": "TokenEndpointTransportCertValidationFilter",
+          "type": "TokenEndpointTransportCertValidationFilter",
           "config": {
             "trustedDirectoryService": "TrustedDirectoriesService",
             "jwkSetService": "OBJwkSetService",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/06-ob-as-par.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/06-ob-as-par.json
@@ -38,9 +38,9 @@
           "comment": "Ensure authorize request object is FAPI compliant"
         },
         {
-          "name": "ResponsePathTransportCertValidationFilter",
-          "type": "ResponsePathTransportCertValidationFilter",
-          "comment": "Verify that the client's transport cert is valid and is mapped to their SSA",
+          "name": "ParEndpointTransportCertValidationFilter",
+          "type": "ParEndpointTransportCertValidationFilter",
+          "comment": "Verify that the client's transport cert is valid (if supplied for mTLS auth) and is mapped to their SSA",
           "config": {
             "trustedDirectoryService": "TrustedDirectoriesService",
             "jwkSetService": "OBJwkSetService",


### PR DESCRIPTION
ResponsePathTransportCertValidationFilter has been replaced with endpoint specific filters: TokenEndpointTransportCertValidationFilter and ParEndpointTransportCertValidationFilter.

Related core PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/44

https://github.com/SecureApiGateway/SecureApiGateway/issues/1305