### PR TITLE
1413: Configure StaticTrustedDirectoryService

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -127,7 +127,7 @@
             "name": "FetchTrustedDirectoryFilter",
             "type": "FetchTrustedDirectoryFilter",
             "config": {
-              "trustedDirectoryService": "TrustedDirectoriesService"
+              "trustedDirectoryService": "TrustedDirectoryService"
             }
           },
           {
@@ -401,12 +401,43 @@
       }
     },
     {
-      "name": "TrustedDirectoriesService",
-      "type": "TrustedDirectoriesService",
+      "name": "TrustedDirectoryService",
+      "type": "StaticTrustedDirectoryService",
       "comment": "Used to obtain meta information about a trusted directory by look up using the 'iss' field value",
       "config": {
-        "enableIGTestTrustedDirectory": "${security.enableTestTrustedDirectory}",
-        "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks"
+        "trustedDirectories": [
+          {
+            "name": "Open Banking Test Directory",
+            "type": "TrustedDirectory",
+            "config": {
+              "directoryJwksUri": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
+              "issuer": "OpenBanking Ltd",
+              "softwareStatementJwksUriClaimName": "software_jwks_endpoint",
+              "softwareStatementOrgIdClaimName": "org_id",
+              "softwareStatementOrgNameClaimName": "org_name",
+              "softwareStatementSoftwareIdClaimName": "software_id",
+              "softwareStatementRedirectUrisClaimName": "software_redirect_uris",
+              "softwareStatementRolesClaimName": "software_roles",
+              "softwareStatementClientNameClaimName": "software_client_name"
+            }
+          },
+          {
+            "name": "Secure API Gateway Test Directory",
+            "type": "TrustedDirectory",
+            "config": {
+              "directoryJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks",
+              "issuer": "test-publisher",
+              "softwareStatementJwksClaimName": "software_jwks",
+              "softwareStatementOrgIdClaimName": "org_id",
+              "softwareStatementOrgNameClaimName": "org_name",
+              "softwareStatementSoftwareIdClaimName": "software_id",
+              "softwareStatementRedirectUrisClaimName": "software_redirect_uris",
+              "softwareStatementRolesClaimName": "software_roles",
+              "softwareStatementClientNameClaimName": "software_client_name",
+              "disabled": "${!security.enableTestTrustedDirectory}"
+            }
+          }
+        ]
       }
     },
     {

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -115,7 +115,7 @@
             "name": "FetchTrustedDirectoryFilter",
             "type": "FetchTrustedDirectoryFilter",
             "config": {
-              "trustedDirectoryService": "TrustedDirectoriesService"
+              "trustedDirectoryService": "TrustedDirectoryService"
             }
           },
           {
@@ -389,12 +389,43 @@
       }
     },
     {
-      "name": "TrustedDirectoriesService",
-      "type": "TrustedDirectoriesService",
+      "name": "TrustedDirectoryService",
+      "type": "StaticTrustedDirectoryService",
       "comment": "Used to obtain meta information about a trusted directory by look up using the 'iss' field value",
       "config": {
-        "enableIGTestTrustedDirectory": "${security.enableTestTrustedDirectory}",
-        "SecureApiGatewayJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks"
+        "trustedDirectories": [
+          {
+            "name": "Open Banking Test Directory",
+            "type": "TrustedDirectory",
+            "config": {
+              "directoryJwksUri": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
+              "issuer": "OpenBanking Ltd",
+              "softwareStatementJwksUriClaimName": "software_jwks_endpoint",
+              "softwareStatementOrgIdClaimName": "org_id",
+              "softwareStatementOrgNameClaimName": "org_name",
+              "softwareStatementSoftwareIdClaimName": "software_id",
+              "softwareStatementRedirectUrisClaimName": "software_redirect_uris",
+              "softwareStatementRolesClaimName": "software_roles",
+              "softwareStatementClientNameClaimName": "software_client_name"
+            }
+          },
+          {
+            "name": "Secure API Gateway Test Directory",
+            "type": "TrustedDirectory",
+            "config": {
+              "directoryJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks",
+              "issuer": "test-publisher",
+              "softwareStatementJwksClaimName": "software_jwks",
+              "softwareStatementOrgIdClaimName": "org_id",
+              "softwareStatementOrgNameClaimName": "org_name",
+              "softwareStatementSoftwareIdClaimName": "software_id",
+              "softwareStatementRedirectUrisClaimName": "software_redirect_uris",
+              "softwareStatementRolesClaimName": "software_roles",
+              "softwareStatementClientNameClaimName": "software_client_name",
+              "disabled": "${!security.enableTestTrustedDirectory}"
+            }
+          }
+        ]
       }
     },
     {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/03-ob-dcr-register-tpp.json
@@ -43,7 +43,7 @@
           "name": "RegistrationRequestBuilderFilter",
           "type": "RegistrationRequestBuilderFilter",
           "config": {
-            "trustedDirectoryService": "TrustedDirectoriesService"
+            "trustedDirectoryService": "TrustedDirectoryService"
           }
         },
         {
@@ -82,7 +82,7 @@
               "allowIgIssuedTestCerts": "${security.enableTestTrustedDirectory}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}",
               "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
-              "trustedDirectoryService": "${heap['TrustedDirectoriesService']}"
+              "trustedDirectoryService": "${heap['TrustedDirectoryService']}"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/05-ob-as-token-endpoint.json
@@ -77,7 +77,7 @@
           "name": "TokenEndpointTransportCertValidationFilter",
           "type": "TokenEndpointTransportCertValidationFilter",
           "config": {
-            "trustedDirectoryService": "TrustedDirectoriesService",
+            "trustedDirectoryService": "TrustedDirectoryService",
             "jwkSetService": "OBJwkSetService",
             "certificateRetriever": "HeaderCertificateRetriever",
             "transportCertValidator": "OBTransportCertValidator"

--- a/config/7.3.0/securebanking/ig/routes/routes-service/06-ob-as-par.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/06-ob-as-par.json
@@ -42,7 +42,7 @@
           "type": "ParEndpointTransportCertValidationFilter",
           "comment": "Verify that the client's transport cert is valid (if supplied for mTLS auth) and is mapped to their SSA",
           "config": {
-            "trustedDirectoryService": "TrustedDirectoriesService",
+            "trustedDirectoryService": "TrustedDirectoryService",
             "jwkSetService": "OBJwkSetService",
             "certificateRetriever": "HeaderCertificateRetriever",
             "transportCertValidator": "OBTransportCertValidator"


### PR DESCRIPTION
The StaticTrustedDirectoryService replaces TrustedDirectoriesService.

It includes configuration for the Open Banking and Secure API Gateway Test directories which have been migrated from code to config.

Related core PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/40

https://github.com/SecureApiGateway/SecureApiGateway/issues/1413