### PR TITLE
1475: Upgrade openIG to 2024.6 ready for SAPIG 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <secure-api-gateway.version>3.0.0</secure-api-gateway.version>
+        <secure-api-gateway.version>3.0.1-SNAPSHOT</secure-api-gateway.version>
         <nimbus-jose.version>9.37.3</nimbus-jose.version>
         <bouncy-castle.version>1.77</bouncy-castle.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
         <secure-api-gateway.version>3.0.1-SNAPSHOT</secure-api-gateway.version>
-        <nimbus-jose.version>9.37.3</nimbus-jose.version>
+        <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.77</bouncy-castle.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <properties>
         <secure-api-gateway.version>3.0.1-SNAPSHOT</secure-api-gateway.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
-        <bouncy-castle.version>1.77</bouncy-castle.version>
+        <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
     </properties>
 

--- a/secure-api-gateway-ob-uk-docker/Dockerfile
+++ b/secure-api-gateway-ob-uk-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2024.3.0
+FROM gcr.io/forgerock-io/ig:2024.6.0
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
docker image to `2026.4.0 `
core version to `3.0.1-SNAPSHOT`
parent version to `3.0.1-SNAPSHOT`
nimbus-jose version `9.40`
bouncy-castle version to `1.78.1`

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1475