### PR TITLE
1512: Make pass-through route send all traffic to Identity Platform

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-pod/99-kube-probe.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-pod/99-kube-probe.json
@@ -1,5 +1,5 @@
 {
-   "name": "Kubernetes endpoints",
+   "name": "99 - Kubernetes endpoints",
    "condition": "${find(request.uri.path, '^/kube')}",
    "handler": {
       "type": "DispatchHandler",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/999-ob-as-passthrough.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/999-ob-as-passthrough.json
@@ -1,9 +1,8 @@
 {
-  "comment": "Passthrough for any unprotected AM endpoints (such as the XUI)",
-  "name": "99 - OBIE AS pass-through",
+  "comment": "Pass-through for any unprotected Identity Platform endpoints (such as the XUI) - the name of this route needs to be last alphabetically so that more specific routes can be used if they exist.",
+  "name": "999 - OBIE AS pass-through",
   "auditService": "AuditService-OB-Route",
   "baseURI": "https://&{identity.platform.fqdn}",
-  "condition": "${find(request.uri.path, '^/am')}",
   "handler": {
     "type": "Chain",
     "config": {


### PR DESCRIPTION
Rename 99-as-passthrough.json to 999-platform-passthrough.json so that it is last in the route list. Update route name to reflect this.

The route is now responsible for passing any requests, which have not already been routed, through to the Identity Platform.

This includes AM endpoints such as the XUI and IDM endpoints to fetch config used to render the XUI.

Fix name of 98-kube-probe.json route for consistency.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1512