### PR TITLE
1605: Make sure dev branches are not using latest snapshots for artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Bump Common to snapshot version 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1605