### PR TITLE
1642: Create SAPIG 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <properties>
-        <secure-api-gateway.version>4.0.2-SNAPSHOT</secure-api-gateway.version>
+        <secure-api-gateway.version>4.0.4</secure-api-gateway.version>
         <openig.version>2024.11.0</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>


### PR DESCRIPTION
- Revert Parent to `4.0.0` as no changes in repo to be released
- Bump Core to `4.0.4`

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1642